### PR TITLE
chore: improve markdown formatting of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Jenkins X - Terraform AWS EKS
+
 A terraform module to create an EKS cluster and all the necessary infrastructure that serves as an alternative to `jx create cluster eks`.
 
 This module is based on the Terraform EKS cluster that can be found here: https://github.com/terraform-aws-modules/terraform-aws-eks.
@@ -14,9 +16,19 @@ It's required that both kubectl (>=1.10) and aws-iam-authenticator are installed
 
 This module works with a series of variables with default values, this will let you easily run it with a default configuration for easy prototyping by just providing the following required variables:
 
-    terraform init
+```bash
+terraform init
+```
 
-    terraform apply -var 'cluster_name=<cluster_name>' -var 'region=<your_aws_region>' -var 'account_id=<your_aws_account_id>' 
+```bash
+CLUSTER_NAME=
+REGION=<your_aws_region>
+ACCOUNT_ID=<your_aws_account_id>
+```
+
+```bash
+terraform apply -var 'cluster_name=$CLUSTER_NAME' -var 'region=$REGION' -var 'account_id=$ACCOUNT_ID'
+```
 
 Full customization of the EKS and Kubernetes modules through the use of this module is still not supported as this is still work in progress.
 
@@ -26,6 +38,7 @@ There are a number of variables that will let you configure some resources for y
 
 With these variables you can define a few variables for the VPC that will be created:
 
+```terraform
     variable "vpc_name" {
       description  = "The name of the VPC to be created for the cluster"
       type         = string
@@ -43,11 +56,13 @@ With these variables you can define a few variables for the VPC that will be cre
       type        = string
       default     = "10.0.0.0/16"
     }
+```
 
 ### EKS Worker Nodes configration
 
 With these variables you can configure the worker nodes pool for the EKS cluster:
 
+```terraform
     variable "desired_number_of_nodes" {
       description = "The desired number of worker nodes to use for the cluster. Defaults to 3"
       type        = number
@@ -71,11 +86,13 @@ With these variables you can configure the worker nodes pool for the EKS cluster
       type         = string
       default      = "m5.large"
     }
+```
 
 ### Long Term Storage
 
 You can choose whether to create S3 buckets for long term storage and enable them in the generated `jx-requirements.yml` file.
 
+```terraform
     variable "enable_logs_storage" {
       description = "Flag to enable or disable long term storage for logs"
       type        = bool
@@ -93,19 +110,22 @@ You can choose whether to create S3 buckets for long term storage and enable the
       type        = bool
       default     = true
     }
+```
 
 If these variables are `true`, after creating the necessary S3 buckets, it will configure the `jx-requirements.yml` file in the following section:
 
-    storage:
-      logs:
-        enabled: ${enable_logs_storage}
-        url: s3://${logs_storage_bucket}
-      reports:
-        enabled: ${enable_reports_storage}
-        url: s3://${reports_storage_bucket}
-      repository:
-        enabled: ${enable_repository_storage}
-        url: s3://${repository_storage_bucket}
+```yaml
+storage:
+  logs:
+    enabled: ${enable_logs_storage}
+    url: s3://${logs_storage_bucket}
+  reports:
+    enabled: ${enable_reports_storage}
+    url: s3://${reports_storage_bucket}
+  repository:
+    enabled: ${enable_repository_storage}
+    url: s3://${repository_storage_bucket}
+```
 
 ### Vault configuration
 
@@ -113,18 +133,22 @@ With this module, we can choose to create the Vault resources that will be used 
 
 You can enable the creation of the Vault resources with the following variable:
 
-    variable "create_vault_resources" {
-      description = "Flag to enable or disable the creation of Vault resources by Terraform"
-      type        = bool
-      default     = false
-    }
+```terraform
+variable "create_vault_resources" {
+  description = "Flag to enable or disable the creation of Vault resources by Terraform"
+  type        = bool
+  default     = false
+}
+```
 
 If `create_vault_resources` is `true`, the `vault_user` variable will be required:
 
-    variable "vault_user" {
-      type    = string
-      default = ""
-    }
+```terraform
+variable "vault_user" {
+  type    = string
+  default = ""
+}
+```
 
 ### External DNS and Cert Manager
 
@@ -132,42 +156,50 @@ If `create_vault_resources` is `true`, the `vault_user` variable will be require
 
 You can enable External DNS with the following variable:
 
-    variable "enable_external_dns" {
-      description = "Flag to enable or disable External DNS in the final `jx-requirements.yml` file"
-      type        = bool
-      default     = false
-    }
+```terraform
+variable "enable_external_dns" {
+  description = "Flag to enable or disable External DNS in the final `jx-requirements.yml` file"
+  type        = bool
+  default     = false
+}
+```
 
 If `enable_external_dns` is true, additional configuration will be required:
 
 If you want to use a domain with an already existing Route 53 Hosted Zone, you can provide it through the following variable:
 
-    variable "apex_domain" {
-      description = "Flag to enable or disable long term storage for logs"
-      type        = string
-      default     = ""
-    }
+```terraform
+variable "apex_domain" {
+  description = "Flag to enable or disable long term storage for logs"
+  type        = string
+  default     = ""
+}
+```
 
 This domain will be configured in the resulting `jx-requirements.yml` file in the following section:
 
-    ingress:
-      domain: ${domain}
-      ignoreLoadBalancer: true
-      externalDNS: ${enable_external_dns}
+```yaml
+ingress:
+  domain: ${domain}
+  ignoreLoadBalancer: true
+  externalDNS: ${enable_external_dns}
+```
 
 If you want use a subdomain and have this script create and configure a new Hosted Zone with DNS delegation, you can provide the following variables:
 
-    variable "subdomain" {
-      description = "The subdomain to be used added to the apex domain. If subdomain is set, it will be appended to the apex domain in  `jx-requirements-eks.yml` file"
-      type        = string
-      default     = ""
-    }
-    
-    variable "create_and_configure_subdomain" {
-      description = "Flag to create an NS record ser for the subdomain in the apex domain's Hosted Zone"
-      type        = bool
-      default     = false
-    }
+```terraform
+variable "subdomain" {
+  description = "The subdomain to be used added to the apex domain. If subdomain is set, it will be appended to the apex domain in  `jx-requirements-eks.yml` file"
+  type        = string
+  default     = ""
+}
+
+variable "create_and_configure_subdomain" {
+  description = "Flag to create an NS record ser for the subdomain in the apex domain's Hosted Zone"
+  type        = bool
+  default     = false
+}
+```
 
 By providing these variables, the script will create a new `Route 53` HostedZone that looks like `<subdomain>.<apex_domain>` and it will delegate the resolving of DNS to the apex domain.
 This is done by creating a `NS` RecordSet in the apex domain's Hosted Zone with the subdomain's HostedZone nameservers.
@@ -178,29 +210,35 @@ This will make sure that the newly created HostedZone for the subdomain is insta
 
 You can enable Cert Manager in order to use TLS for your cluster through LetsEncrypt with the following variables:
 
-    variable "enable_tls" {
-      description = "Flag to enable TLS int he final `jx-requirements.yml` file"
-      type        = bool
-      default     = false
-    }
+```terraform
+variable "enable_tls" {
+  description = "Flag to enable TLS int he final `jx-requirements.yml` file"
+  type        = bool
+  default     = false
+}
+```
 
 LetsEncrypt has two environments, `staging` and `production`, the difference is that if you use staging, you will be provided self signed certificates but will not be rate limited while if you use the `production` environment, you will be provided certificates signed by LetsEncrypt but you can be rate limited.
 
 You can choose to use the `production` environment with the following variable: 
 
-    variable "production_letsencrypt" {
-      description = "Flag to use the production environment of letsencrypt in the `jx-requirements.yml` file"
-      type        = bool
-      default     = false
-    }
+```terraform
+variable "production_letsencrypt" {
+  description = "Flag to use the production environment of letsencrypt in the `jx-requirements.yml` file"
+  type        = bool
+  default     = false
+}
+```
 
 You will also need to provide a valid email to register your domain in LetsEncrypt:
 
-    variable "tls_email" {
-      description = "The email to register the LetsEncrypt certificate with. Added to the `jx-requirements.yml` file"
-      type        = string
-      default     = ""
-    }
+```terraform
+variable "tls_email" {
+  description = "The email to register the LetsEncrypt certificate with. Added to the `jx-requirements.yml` file"
+  type        = string
+  default     = ""
+}
+```
 
 ## Generation of jx-requirements.yml
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,18 @@ This module is based on the Terraform EKS cluster that can be found here: https:
 This module will also create the necessary resources that Jenkins X will need in order to be installed in this cluster using `jx boot` using the generated `jx-requirements.yml` which should be preconfigured with all the resources that were created by this module.
 
 ## Assumptions
+
 You want to create an EKS cluster that will be used to install Jenkins X into.
 
 It's required that both kubectl (>=1.10) and aws-iam-authenticator are installed and on your shell's PATH.
 
 ## Usage example
+
 This module works with a series of variables with default values, this will let you easily run it with a default configuration for easy prototyping by just providing the following required variables:
 
     terraform init
-    terraaform apply -var 'cluster_name=<cluster_name>' -var 'region=<your_aws_region>' -var 'account_id=<your_aws_account_id>' 
+
+    terraform apply -var 'cluster_name=<cluster_name>' -var 'region=<your_aws_region>' -var 'account_id=<your_aws_account_id>' 
 
 Full customization of the EKS and Kubernetes modules through the use of this module is still not supported as this is still work in progress.
 
@@ -199,7 +202,6 @@ You will also need to provide a valid email to register your domain in LetsEncry
       default     = ""
     }
 
-
 ## Generation of jx-requirements.yml
 
 The final output of running this module will not only be the creation of cloud resources but also, it will generate a valid `jx-requirements.yml` file that will be used by Jenkins X through `jx boot -r jx-requirements.yml`.
@@ -208,11 +210,13 @@ The template can be found in:
 https://github.com/jenkins-x/jx-cloud-provisioners/blob/master/eks/terraform/jx/jx-requirements.yml.tpl
 
 ## Conditional creation
+
 Sometimes you need to have a way to create resources conditionally but Terraform does not allow to use count inside module block, there still isn't a solution for this in this repository but we will be working to allow users to provide their own VPC, subnets etc.
 
 ## FAQ: Frequently Asked Questions
 
 ### IAM Roles for Service Accounts
+
 This module will setup a series of IAM Policies and Roles. These roles will be annotated into a few Kubernetes Service accounts.
 
 This allows us to make use of IAM Roles for Sercive Accounts in order to set fine grained permissions on a pod per pod basis.

--- a/README.md
+++ b/README.md
@@ -152,9 +152,7 @@ variable "vault_user" {
 }
 ```
 
-### External DNS and Cert Manager
-
-#### External DNS
+### External DNS
 
 You can enable External DNS with the following variable:
 
@@ -208,7 +206,7 @@ This is done by creating a `NS` RecordSet in the apex domain's Hosted Zone with 
 
 This will make sure that the newly created HostedZone for the subdomain is instantly resolveable instead of having to wait for DNS propagation.
 
-#### Cert Manager
+### Cert Manager
 
 You can enable Cert Manager in order to use TLS for your cluster through LetsEncrypt with the following variables:
 

--- a/README.md
+++ b/README.md
@@ -6,28 +6,30 @@ This module is based on the Terraform EKS cluster that can be found here: https:
 
 This module will also create the necessary resources that Jenkins X will need in order to be installed in this cluster using `jx boot` using the generated `jx-requirements.yml` which should be preconfigured with all the resources that were created by this module.
 
-## Assumptions
+## Assumptions
 
 You want to create an EKS cluster that will be used to install Jenkins X into.
 
-It's required that both kubectl (>=1.10) and aws-iam-authenticator are installed and on your shell's PATH.
+It's required that both kubectl (`>=1.10`) and [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator) are installed and on your shell's PATH.
 
-## Usage example
+## Usage example
 
 This module works with a series of variables with default values, this will let you easily run it with a default configuration for easy prototyping by just providing the following required variables:
 
-```bash
+```sh
 terraform init
 ```
 
-```bash
+```sh
 CLUSTER_NAME=
 REGION=<your_aws_region>
 ACCOUNT_ID=<your_aws_account_id>
 ```
 
-```bash
-terraform apply -var 'cluster_name=$CLUSTER_NAME' -var 'region=$REGION' -var 'account_id=$ACCOUNT_ID'
+```sh
+terraform apply -var 'cluster_name=$CLUSTER_NAME' \
+   -var 'region=$REGION' \
+   -var 'account_id=$ACCOUNT_ID'
 ```
 
 Full customization of the EKS and Kubernetes modules through the use of this module is still not supported as this is still work in progress.
@@ -39,23 +41,23 @@ There are a number of variables that will let you configure some resources for y
 With these variables you can define a few variables for the VPC that will be created:
 
 ```terraform
-    variable "vpc_name" {
-      description  = "The name of the VPC to be created for the cluster"
-      type         = string
-      default      = "tf-vpc-eks"
-    }
+variable "vpc_name" {
+  description  = "The name of the VPC to be created for the cluster"
+  type         = string
+  default      = "tf-vpc-eks"
+}
 
-    variable "vpc_subnets" {
-      description = "The subnet CIDR block to use in the created VPC"
-      type        = list(string)
-      default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-    }
+variable "vpc_subnets" {
+  description = "The subnet CIDR block to use in the created VPC"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+}
 
-    variable "vpc_cidr_block" {
-      description = "The vpc CIDR block"
-      type        = string
-      default     = "10.0.0.0/16"
-    }
+variable "vpc_cidr_block" {
+  description = "The vpc CIDR block"
+  type        = string
+  default     = "10.0.0.0/16"
+}
 ```
 
 ### EKS Worker Nodes configration
@@ -63,29 +65,29 @@ With these variables you can define a few variables for the VPC that will be cre
 With these variables you can configure the worker nodes pool for the EKS cluster:
 
 ```terraform
-    variable "desired_number_of_nodes" {
-      description = "The desired number of worker nodes to use for the cluster. Defaults to 3"
-      type        = number
-      default     = 3
-    }
+variable "desired_number_of_nodes" {
+  description = "The desired number of worker nodes to use for the cluster. Defaults to 3"
+  type        = number
+  default     = 3
+}
 
-    variable "min_number_of_nodes" {
-      description = "The minimum number of worker nodes to use for the cluster. Defaults to 3"
-      type        = number
-      default     = 3
-    }
+variable "min_number_of_nodes" {
+  description = "The minimum number of worker nodes to use for the cluster. Defaults to 3"
+  type        = number
+  default     = 3
+}
 
-    variable "max_number_of_nodes" {
-      description = "The maximum number of worker nodes to use for the cluster. Defaults to 5"
-      type        = number
-      default     = 5
-    }
+variable "max_number_of_nodes" {
+  description = "The maximum number of worker nodes to use for the cluster. Defaults to 5"
+  type        = number
+  default     = 5
+}
 
-    variable "worker_nodes_instance_types" {
-      description  = "The instance type to use for the cluster's worker nodes. Defaults to m5.large"
-      type         = string
-      default      = "m5.large"
-    }
+variable "worker_nodes_instance_types" {
+  description  = "The instance type to use for the cluster's worker nodes. Defaults to m5.large"
+  type         = string
+  default      = "m5.large"
+}
 ```
 
 ### Long Term Storage
@@ -93,23 +95,23 @@ With these variables you can configure the worker nodes pool for the EKS cluster
 You can choose whether to create S3 buckets for long term storage and enable them in the generated `jx-requirements.yml` file.
 
 ```terraform
-    variable "enable_logs_storage" {
-      description = "Flag to enable or disable long term storage for logs"
-      type        = bool
-      default     = true
-    }
+variable "enable_logs_storage" {
+  description = "Flag to enable or disable long term storage for logs"
+  type        = bool
+  default     = true
+}
 
-    variable "enable_reports_storage" {
-      description = "Flag to enable or disable long term storage for reports"
-      type        = bool
-      default     = true
-    }
+variable "enable_reports_storage" {
+  description = "Flag to enable or disable long term storage for reports"
+  type        = bool
+  default     = true
+}
 
-    variable "enable_repository_storage" {
-      description = "Flag to enable or disable the repository bucket storage"
-      type        = bool
-      default     = true
-    }
+variable "enable_repository_storage" {
+  description = "Flag to enable or disable the repository bucket storage"
+  type        = bool
+  default     = true
+}
 ```
 
 If these variables are `true`, after creating the necessary S3 buckets, it will configure the `jx-requirements.yml` file in the following section:
@@ -127,7 +129,7 @@ storage:
     url: s3://${repository_storage_bucket}
 ```
 
-### Vault configuration
+### Vault configuration
 
 With this module, we can choose to create the Vault resources that will be used by Jenkins X.
 
@@ -150,7 +152,7 @@ variable "vault_user" {
 }
 ```
 
-### External DNS and Cert Manager
+### External DNS and Cert Manager
 
 #### External DNS
 
@@ -247,7 +249,7 @@ The template can be found in:
 
 https://github.com/jenkins-x/jx-cloud-provisioners/blob/master/eks/terraform/jx/jx-requirements.yml.tpl
 
-## Conditional creation
+## Conditional creation
 
 Sometimes you need to have a way to create resources conditionally but Terraform does not allow to use count inside module block, there still isn't a solution for this in this repository but we will be working to allow users to provide their own VPC, subnets etc.
 


### PR DESCRIPTION
The readme was not rendering properly. Some headers were not parsed, showing as `### header` and the code snippets had no type information. It seems GitHub markdown does support them, so adding them makes them more readable as they get highlighting.