### PR TITLE
fix(tekton-bot-policy): add missing ecr policy access permission

### DIFF
--- a/modules/cluster/irsa.tf
+++ b/modules/cluster/irsa.tf
@@ -22,6 +22,7 @@ data "aws_iam_policy_document" "tekton-bot-policy" {
           "cloudformation:DeleteStack",
           "eks:*",
           "s3:*",
+          "ecr:*",      
           "iam:DetachRolePolicy",
           "iam:GetPolicy",
           "iam:CreatePolicy",


### PR DESCRIPTION
This PR fixes missing ECR access policy permission that breaks build pipeline with the error:

```
error checking push permissions -- make sure you entered the correct tag name, and that you are authenticated correctly, and try again: checking push permission for "XXXXXXXXXX.dkr.ecr.us-east-1.amazonaws.com/igdianov/test-springboot-app:0.0.1": unsupported status code 401; body: Not Authorized


Pipeline failed on stage 'from-build-pack' : container 'step-build-container-build'. The execution of the pipeline has stopped.
```

fixes #33 