### PR TITLE
fix: expose cluster version variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,18 @@ A default Jenkins X ready cluster can be provisioned by creating a _main.tf_ fil
 ```terraform
 module "eks-jx" {
   source  = "jenkins-x/eks-jx/aws"
-
-  output "vault_user_id" {
-    value       = module.eks-jx.vault_user_id
-    description = "The Vault IAM user id"
-  }
-
-  output "vault_user_secret" {
-    value       = module.eks-jx.vault_user_secret
-    description = "The Vault IAM user secret"
-  }
 }
+
+output "vault_user_id" {
+  value       = module.eks-jx.vault_user_id
+  description = "The Vault IAM user id"
+}
+
+output "vault_user_secret" {
+  value       = module.eks-jx.vault_user_secret
+  description = "The Vault IAM user secret"
+}
+
 ```
 
 Due to the Vault issue [7450](https://github.com/hashicorp/vault/issues/7450), this Terraform module needs for now to create a new IAM user for installing Vault.
@@ -120,6 +121,7 @@ The following sections provide a full list of configuration in- and output varia
 |------|-------------|------|---------|:-----:|
 | apex\_domain | The main domain to either use directly or to configure a subdomain from | `string` | `""` | no |
 | cluster\_name | Variable to provide your desired name for the cluster. The script will create a random name if this is empty | `string` | `""` | no |
+| cluster\_version | Variable to provide your desired Kubernetes version for the cluster. | `string` | `"1.15"` | no |
 | create\_and\_configure\_subdomain | Flag to create an NS record set for the subdomain in the apex domain's Hosted Zone | `bool` | `false` | no |
 | desired\_node\_count | The number of worker nodes to use for the cluster | `number` | `3` | no |
 | enable\_external\_dns | Flag to enable or disable External DNS in the final `jx-requirements.yml` file | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,7 @@ provider "template" {
 module "cluster" {
   source             = "./modules/cluster"
   cluster_name       = local.cluster_name
+  cluster_version    = var.cluster_version
   desired_node_count = var.desired_node_count
   min_node_count     = var.min_node_count
   max_node_count     = var.max_node_count

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -55,6 +55,7 @@ module "eks" {
   source        = "terraform-aws-modules/eks/aws"
   version       = "10.0.0"
   cluster_name  = var.cluster_name
+  cluster_version  = var.cluster_version
   subnets       = module.vpc.public_subnets
   vpc_id        = module.vpc.vpc_id
   enable_irsa   = true

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -2,6 +2,11 @@ variable "cluster_name" {
   type = string
 }
 
+variable "cluster_version" {
+  description = "Kubernetes version to use for the EKS cluster."
+  type        = string
+}
+
 # Worker Nodes
 variable "desired_node_count" {
   type        = number

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,12 @@ variable "cluster_name" {
   type        = string
   default     = ""
 }
+  
+variable "cluster_version" {
+  description = "Kubernetes version to use for the EKS cluster."
+  type        = string
+  default     = "1.15"
+}  
 
 // ----------------------------------------------------------------------------
 variable "vault_user" {


### PR DESCRIPTION
This PR adds support to specify EKS cluster version via `cluster_version` variable, i.e.

```terraform
module "eks-jx" {
  source  = "jenkins-x/eks-jx/aws"
  cluster_version = "1.XX"
}

```