### PR TITLE
fix: use data source to attach vault policy

### DIFF
--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -171,6 +171,6 @@ resource "aws_iam_policy" "aws_vault_user_policy" {
 }
 
 resource "aws_iam_user_policy_attachment" "attach_vault_policy_to_user" {
-  user       = var.vault_user
+  user       = data.aws_iam_user.vault_user.user_name
   policy_arn = aws_iam_policy.aws_vault_user_policy.arn
 }


### PR DESCRIPTION
When `vault_user` input parameter is empty, it causes the below error now:
```
Error: Error attaching policy arn:aws:iam::<account>:policy/vault_<region>-<timestamp> to IAM User : InvalidParameter: 1 validation error(s) found.
- minimum field size of 1, AttachUserPolicyInput.UserName.
  on modules/vault/main.tf line 173, in resource "aws_iam_user_policy_attachment" "attach_vault_policy_to_user":
 173: resource "aws_iam_user_policy_attachment" "attach_vault_policy_to_user" {
```

fixes #46 