### PR TITLE
feat: adding an option to use spot instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The module makes use of the [Terraform EKS cluster Module](https://github.com/te
     - [Running `jx boot`](#running-jx-boot)
     - [Production cluster considerations](#production-cluster-considerations)
     - [Configuring a Terraform backend](#configuring-a-terraform-backend)
+    - [Using Spot Instances](#using-spot-instances)
     - [Examples](#examples)
 - [FAQ: Frequently Asked Questions](#faq-frequently-asked-questions)
     - [IAM Roles for Service Accounts](#iam-roles-for-service-accounts)
@@ -129,6 +130,7 @@ The following sections provide a full list of configuration in- and output varia
 | enable\_logs\_storage | Flag to enable or disable long term storage for logs | `bool` | `true` | no |
 | enable\_reports\_storage | Flag to enable or disable long term storage for reports | `bool` | `true` | no |
 | enable\_repository\_storage | Flag to enable or disable the repository bucket storage | `bool` | `true` | no |
+| enable\_spot\_instances | Flag to enable Spot Instances | `bool` | `false` | no |
 | enable\_tls | Flag to enable TLS in the final `jx-requirements.yml` file | `bool` | `false` | no |
 | force\_destroy | Flag to determine whether storage buckets get forcefully destroyed. If set to false, empty the bucket first in the aws s3 console, else terraform destroy will fail with BucketNotEmpty error | `bool` | `false` | no |
 | max\_node\_count | The maximum number of worker nodes to use for the cluster | `number` | `5` | no |
@@ -136,6 +138,7 @@ The following sections provide a full list of configuration in- and output varia
 | node\_machine\_type | The instance type to use for the cluster's worker nodes | `string` | `"m5.large"` | no |
 | production\_letsencrypt | Flag to use the production environment of letsencrypt in the `jx-requirements.yml` file | `bool` | `false` | no |
 | region | The region to create the resources into | `string` | `"us-east-1"` | no |
+| spot_price | The ceiling price for spot instances | `string` | `"0.1"` | no |
 | subdomain | The subdomain to be added to the apex domain. If subdomain is set, it will be appended to the apex domain in  `jx-requirements-eks.yml` file | `string` | `""` | no |
 | tls\_email | The email to register the LetsEncrypt certificate with. Added to the `jx-requirements.yml` file | `string` | `""` | no |
 | vault\_user | The AWS IAM Username whose credentials will be used to authenticate the Vault pods against AWS | `string` | `""` | no |
@@ -292,6 +295,12 @@ The [examples](./examples) directory of this repository contains configuration e
 To use the _s3_ backend, you will need to create the bucket upfront.
 You need the S3 bucket as well as a Dynamo table for state locks.
 You can use [terraform-aws-tfstate-backend](https://github.com/cloudposse/terraform-aws-tfstate-backend) to create these required resources.
+
+### Using Spot Instances
+<a id="markdown-Using%20Spot%20Instances" name="Using%20Spot%20Instances"></a>
+You can save up to 90% of cost when you use Spot Instances. You just need to make sure your applications are resilient. You can set the ceiling `spot_price` of what you want to pay then set `enable_spot_instances` to `true`.
+
+:warning: **Note**: If the price of the instance reaches this point it will be terminated.
 
 ### Examples
 <a id="markdown-Examples" name="Examples"></a>

--- a/main.tf
+++ b/main.tf
@@ -32,17 +32,19 @@ provider "template" {
 // See https://www.terraform.io/docs/providers/aws/r/eks_cluster.html
 // ----------------------------------------------------------------------------
 module "cluster" {
-  source             = "./modules/cluster"
-  cluster_name       = local.cluster_name
-  cluster_version    = var.cluster_version
-  desired_node_count = var.desired_node_count
-  min_node_count     = var.min_node_count
-  max_node_count     = var.max_node_count
-  node_machine_type  = var.node_machine_type
-  vpc_name           = var.vpc_name
-  vpc_subnets        = var.vpc_subnets
-  vpc_cidr_block     = var.vpc_cidr_block
-  force_destroy      = var.force_destroy
+  source                = "./modules/cluster"
+  cluster_name          = local.cluster_name
+  cluster_version       = var.cluster_version
+  desired_node_count    = var.desired_node_count
+  min_node_count        = var.min_node_count
+  max_node_count        = var.max_node_count
+  node_machine_type     = var.node_machine_type
+  spot_price            = var.spot_price
+  vpc_name              = var.vpc_name
+  vpc_subnets           = var.vpc_subnets
+  vpc_cidr_block        = var.vpc_cidr_block
+  force_destroy         = var.force_destroy
+  enable_spot_instances = var.enable_spot_instances
 }
 
 // ----------------------------------------------------------------------------

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -66,6 +66,7 @@ module "eks" {
       asg_desired_capacity = var.desired_node_count
       asg_min_size         = var.min_node_count
       asg_max_size         = var.max_node_count
+      spot_price           = (var.enable_spot_instances ? var.spot_price : null)
       tags = [
         {
           "key"                 = "k8s.io/cluster-autoscaler/enabled"

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -44,6 +44,12 @@ variable "vpc_cidr_block" {
   default     = "10.0.0.0/16"
 }
 
+variable "spot_price" {
+  description = "The spot price ceiling for spot instances"
+  type        = string
+  default     = "0.1"
+}
+
 
 // ----------------------------------------------------------------------------
 // Flag Variables
@@ -65,6 +71,12 @@ variable "enable_repository_storage" {
 
 variable "force_destroy" {
   description = "Flag to determine whether storage buckets get forcefully destroyed. If set to false, empty the bucket first in the aws s3 console, else terraform destroy will fail with BucketNotEmpty error"
+  type        = bool
+  default     = false
+}
+
+variable "enable_spot_instances" {
+  description = "Flag to enable spot instances"
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,11 @@ variable "node_machine_type" {
   default     = "m5.large"
 }
 
+variable "spot_price" {
+  description = "The spot price ceiling for spot instances"
+  type        = string
+  default     = "0.1"
+}
 // ----------------------------------------------------------------------------
 // VPC Variables
 // ----------------------------------------------------------------------------
@@ -142,6 +147,12 @@ variable "production_letsencrypt" {
 
 variable "force_destroy" {
   description = "Flag to determine whether storage buckets get forcefully destroyed. If set to false, empty the bucket first in the aws s3 console, else terraform destroy will fail with BucketNotEmpty error"
+  type        = bool
+  default     = false
+}
+
+variable "enable_spot_instances" {
+  description = "Flag to enable spot instances"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
Considering that we can save up to 90% and we are developing resilient applications anyway, we need to add an option that allows using spot instances instead.

fixes #75