### PR TITLE
feat: add support for eks managed node group

### DIFF
--- a/examples/nodegroup/main.tf
+++ b/examples/nodegroup/main.tf
@@ -1,0 +1,5 @@
+module "eks-jx" {
+  source              = "jenkins-x/eks-jx/aws"
+  enable_node_group   = var.enable_node_group   // set to true
+  enable_worker_group = var.enable_worker_group // set to false
+}

--- a/examples/nodegroup/variables.tf
+++ b/examples/nodegroup/variables.tf
@@ -1,0 +1,7 @@
+variable "enable_worker_group" {
+  default = false
+}
+
+variable "enable_node_group" {
+  default = true
+}

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,8 @@ module "cluster" {
   vpc_cidr_block        = var.vpc_cidr_block
   force_destroy         = var.force_destroy
   enable_spot_instances = var.enable_spot_instances
+  enable_node_group     = var.enable_node_group
+  enable_worker_group   = var.enable_worker_group
 }
 
 // ----------------------------------------------------------------------------

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -50,6 +50,19 @@ variable "spot_price" {
   default     = "0.1"
 }
 
+variable "node_group_ami" {
+  description = "ami type for the node group worker intances"
+  type        = string
+  default     = "AL2_x86_64"
+}
+
+variable "node_group_disk_size" {
+  description = "node group worker disk size"
+  type        = string
+  default     = "50"
+}
+
+
 
 // ----------------------------------------------------------------------------
 // Flag Variables
@@ -57,6 +70,18 @@ variable "spot_price" {
 variable "enable_logs_storage" {
   type    = bool
   default = true
+}
+
+variable "enable_node_group" {
+  description = "Flag to enable node group"
+  type        = bool
+  default     = false
+}
+
+variable "enable_worker_group" {
+  description = "Flag to enable worker group"
+  type        = bool
+  default     = true
 }
 
 variable "enable_reports_storage" {

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,19 @@ variable "spot_price" {
   type        = string
   default     = "0.1"
 }
+
+variable "node_group_ami" {
+  description = "ami type for the node group worker intances"
+  type        = string
+  default     = "AL2_x86_64"
+}
+
+variable "node_group_disk_size" {
+  description = "node group worker disk size"
+  type        = string
+  default     = "50"
+}
+
 // ----------------------------------------------------------------------------
 // VPC Variables
 // ----------------------------------------------------------------------------
@@ -155,4 +168,16 @@ variable "enable_spot_instances" {
   description = "Flag to enable spot instances"
   type        = bool
   default     = false
+}
+
+variable "enable_node_group" {
+  description = "Flag to enable node group"
+  type        = bool
+  default     = false
+}
+
+variable "enable_worker_group" {
+  description = "Flag to enable worker group"
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

Two things:
1. Need to decide on tags to use
2. To provision node groups, we have to set `enable_worker_group` explicitely to false, else both node group and self managed worker group instances are provisioned. I have added a readme warning. Is this ok? I did this to maintain backwards compatibility. By default enable_worker_group is true, and enable_node_group is false. We could set both of them to false, and make the end user explicitely specify what we want them to use. Thoughts?

Fixes #66 