### PR TITLE
feat: add an option to be able to specify ssh key pair name, ebs volume size and type to the auto launch configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,16 +32,23 @@ provider "template" {
 // See https://www.terraform.io/docs/providers/aws/r/eks_cluster.html
 // ----------------------------------------------------------------------------
 module "cluster" {
-  source             = "./modules/cluster"
-  cluster_name       = local.cluster_name
-  cluster_version    = var.cluster_version
-  desired_node_count = var.desired_node_count
-  min_node_count     = var.min_node_count
-  max_node_count     = var.max_node_count
-  node_machine_type  = var.node_machine_type
-  vpc_name           = var.vpc_name
-  vpc_subnets        = var.vpc_subnets
-  vpc_cidr_block     = var.vpc_cidr_block
+  source                = "./modules/cluster"
+  cluster_name          = local.cluster_name
+  cluster_version       = var.cluster_version
+  desired_node_count    = var.desired_node_count
+  min_node_count        = var.min_node_count
+  max_node_count        = var.max_node_count
+  node_machine_type     = var.node_machine_type
+  spot_price            = var.spot_price
+  vpc_name              = var.vpc_name
+  vpc_subnets           = var.vpc_subnets
+  vpc_cidr_block        = var.vpc_cidr_block
+  force_destroy         = var.force_destroy
+  enable_spot_instances = var.enable_spot_instances
+  enable_key_name       = var.enable_key_name
+  key_name	 	= var.key_name
+  volume_type		= var.volume_type
+  volume_size		= var.volume_size
 }
 
 // ----------------------------------------------------------------------------
@@ -49,9 +56,10 @@ module "cluster" {
 // See https://github.com/banzaicloud/bank-vaults
 // ----------------------------------------------------------------------------
 module "vault" {
-  source       = "./modules/vault"
-  cluster_name = local.cluster_name
-  vault_user   = var.vault_user
+  source        = "./modules/vault"
+  cluster_name  = local.cluster_name
+  vault_user    = var.vault_user
+  force_destroy = var.force_destroy
 }
 
 // ----------------------------------------------------------------------------
@@ -80,11 +88,11 @@ resource "local_file" "jx-requirements" {
     cluster_name               = local.cluster_name
     region                     = var.region
     enable_logs_storage        = var.enable_logs_storage
-    logs_storage_bucket        = module.cluster.logs_jenkins_x[0]
+    logs_storage_bucket        = length(module.cluster.logs_jenkins_x) > 0 ? module.cluster.logs_jenkins_x[0] : ""
     enable_reports_storage     = var.enable_reports_storage
-    reports_storage_bucket     = module.cluster.reports_jenkins_x[0]
+    reports_storage_bucket     = length(module.cluster.reports_jenkins_x) > 0 ? module.cluster.reports_jenkins_x[0] : ""
     enable_repository_storage  = var.enable_repository_storage
-    repository_storage_bucket  = module.cluster.repository_jenkins_x[0]
+    repository_storage_bucket  = length(module.cluster.repository_jenkins_x) > 0 ? module.cluster.repository_jenkins_x[0] : ""
     vault_kms_key              = module.vault.kms_vault_unseal
     vault_bucket               = module.vault.vault_unseal_bucket
     vault_dynamodb_table       = module.vault.vault_dynamodb_table

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -66,6 +66,11 @@ module "eks" {
       asg_desired_capacity = var.desired_node_count
       asg_min_size         = var.min_node_count
       asg_max_size         = var.max_node_count
+      spot_price           = (var.enable_spot_instances ? var.spot_price : null)
+      key_name             = (var.enable_key_name ? var.key_name : null)
+      root_volume_type     = var.volume_type
+      root_volume_size     = var.volume_size
+      root_iops            = var.iops
       tags = [
         {
           "key"                 = "k8s.io/cluster-autoscaler/enabled"

--- a/modules/cluster/storage.tf
+++ b/modules/cluster/storage.tf
@@ -9,6 +9,7 @@ resource "aws_s3_bucket" "logs_jenkins_x" {
   tags = {
     Owner = "Jenkins-x"
   }
+  force_destroy = var.force_destroy
 }
 
 resource "aws_s3_bucket" "reports_jenkins_x" {
@@ -18,6 +19,7 @@ resource "aws_s3_bucket" "reports_jenkins_x" {
   tags = {
     Owner = "Jenkins-x"
   }
+  force_destroy = var.force_destroy
 }
 
 resource "aws_s3_bucket" "repository_jenkins_x" {
@@ -27,4 +29,5 @@ resource "aws_s3_bucket" "repository_jenkins_x" {
   tags = {
     Owner = "Jenkins-x"
   }
+  force_destroy = var.force_destroy
 }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -44,7 +44,34 @@ variable "vpc_cidr_block" {
   default     = "10.0.0.0/16"
 }
 
+variable "spot_price" {
+  description = "The spot price ceiling for spot instances"
+  type        = string
+  default     = "0.1"
+}
 
+variable "key_name" {
+  description = "The ssh key pair name to use"
+  type        = string
+}
+
+variable "volume_type" {
+  description = "The volume type to use. Can be standard, gp2 or io1"
+  type        = string
+  default     = "gp2"
+}
+
+variable "volume_size" {
+  description = "The volume size in GB"
+  type        = number
+  default     = 10
+}
+
+variable "iops" {
+  description = "The IOPS value"
+  type        = number
+  default     = 0
+}
 // ----------------------------------------------------------------------------
 // Flag Variables
 // ----------------------------------------------------------------------------
@@ -61,4 +88,22 @@ variable "enable_reports_storage" {
 variable "enable_repository_storage" {
   type        = bool
   default     = true
+}
+
+variable "force_destroy" {
+  description = "Flag to determine whether storage buckets get forcefully destroyed. If set to false, empty the bucket first in the aws s3 console, else terraform destroy will fail with BucketNotEmpty error"
+  type        = bool
+  default     = false
+}
+
+variable "enable_spot_instances" {
+  description = "Flag to enable spot instances"
+  type        = bool
+  default     = false
+}
+
+variable "enable_key_name" {
+  description = "Flag to enable ssh key pair name"
+  type        = bool
+  default     = false
 }

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -34,6 +34,7 @@ resource "aws_s3_bucket" "vault-unseal-bucket" {
   versioning {
     enabled = false
   }
+  force_destroy = var.force_destroy
 }
 
 // ----------------------------------------------------------------------------
@@ -42,9 +43,9 @@ resource "aws_s3_bucket" "vault-unseal-bucket" {
 // ----------------------------------------------------------------------------
 resource "aws_dynamodb_table" "vault-dynamodb-table" {
   name           = "vault-unseal-${var.cluster_name}-${local.vault_seed}"
-  billing_mode   = "PROVISIONED"
-  read_capacity  = 2
-  write_capacity = 2
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = 25
+  write_capacity = 25
   hash_key       = "Path"
   range_key      = "Key"
 

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -13,3 +13,9 @@ variable "cluster_name" {
 variable "vault_user" {
   type = string
 }
+
+variable "force_destroy" {
+  description = "Flag to determine whether storage buckets get forcefully destroyed. If set to false, empty the bucket first in the aws s3 console, else terraform destroy will fail with BucketNotEmpty error"
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,34 @@ variable "node_machine_type" {
   default     = "m5.large"
 }
 
+variable "spot_price" {
+  description = "The spot price ceiling for spot instances"
+  type        = string
+  default     = "0.1"
+}
+
+variable "key_name" {
+  description = "The ssh key pair name"
+  type        = string
+}
+
+variable "volume_type" {
+  description = "The volume type to use. Can be standard, gp2 or io1"
+  type        = string
+  default     = "gp2"
+}
+
+variable "volume_size" {
+  description = "The volume size in GB"
+  type        = number
+  default     = 10
+}
+
+variable "iops" {
+  description = "The IOPS value"
+  type        = number
+  default     = 0
+}
 // ----------------------------------------------------------------------------
 // VPC Variables
 // ----------------------------------------------------------------------------
@@ -136,6 +164,24 @@ variable "enable_tls" {
 
 variable "production_letsencrypt" {
   description = "Flag to use the production environment of letsencrypt in the `jx-requirements.yml` file"
+  type        = bool
+  default     = false
+}
+
+variable "force_destroy" {
+  description = "Flag to determine whether storage buckets get forcefully destroyed. If set to false, empty the bucket first in the aws s3 console, else terraform destroy will fail with BucketNotEmpty error"
+  type        = bool
+  default     = false
+}
+
+variable "enable_spot_instances" {
+  description = "Flag to enable spot instances"
+  type        = bool
+  default     = false
+}
+
+variable "enable_key_name" {
+  description = "Flag to enable ssh key pair name"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
There is a need to have the ability to be able to specify SSH Key Pair Name, EBS Volume Size and Type to the Auto Launch Configuration

The Free Tier of DynamoDB can be maximized using 25 RCU and 25 WCU

fixes #83
fixes #84
fixes #86 