### PR TITLE
feat: using private subnets as default and adding an option to use public subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The following sections provide a full list of configuration in- and output varia
 | enable\_reports\_storage | Flag to enable or disable long term storage for reports | `bool` | `true` | no |
 | enable\_repository\_storage | Flag to enable or disable the repository bucket storage | `bool` | `true` | no |
 | enable\_spot\_instances | Flag to enable spot instances | `bool` | `false` | no |
+| cluster\_in\_private\_subnet | Flag to enable installation of cluster on private subnets | `bool` | `false` | no |
 | enable\_tls | Flag to enable TLS in the final `jx-requirements.yml` file | `bool` | `false` | no |
 | enable\_worker\_group | Flag to enable worker group | `bool` | `true` | no |
 | force\_destroy | Flag to determine whether storage buckets get forcefully destroyed. If set to false, empty the bucket first in the aws s3 console, else terraform destroy will fail with BucketNotEmpty error | `bool` | `false` | no |
@@ -154,7 +155,8 @@ The following sections provide a full list of configuration in- and output varia
 | vault\_user | The AWS IAM Username whose credentials will be used to authenticate the Vault pods against AWS | `string` | `""` | no |
 | vpc\_cidr\_block | The vpc CIDR block | `string` | `"10.0.0.0/16"` | no |
 | vpc\_name | The name of the VPC to be created for the cluster | `string` | `"tf-vpc-eks"` | no |
-| vpc\_subnets | The subnet CIDR block to use in the created VPC | `list(string)` | <pre>[<br>  "10.0.1.0/24",<br>  "10.0.2.0/24",<br>  "10.0.3.0/24"<br>]</pre> | no |
+| public\_subnets | The public subnet CIDR block to use in the created VPC | `list(string)` | <pre>[<br>  "10.0.1.0/24",<br>  "10.0.2.0/24",<br>  "10.0.3.0/24"<br>]</pre> | no |
+| private\_subnets | The private subnet CIDR block to use in the created VPC. EKS will be deployed here by default. Use `enable_public_subnet` to override.  | `list(string)` | <pre>[<br>  "10.0.3.0/24",<br>  "10.0.4.0/24",<br>  "10.0.5.0/24"<br>]</pre> | no |
 
 #### Outputs
 
@@ -393,3 +395,4 @@ For the script to work, the environment variable _$GH_TOKEN_ must be exported an
 ## How can I contribute
 
 Contributions are very welcome! Check out the [Contribution Guidelines](./CONTRIBUTING.md) for instructions.
+

--- a/main.tf
+++ b/main.tf
@@ -32,21 +32,23 @@ provider "template" {
 // See https://www.terraform.io/docs/providers/aws/r/eks_cluster.html
 // ----------------------------------------------------------------------------
 module "cluster" {
-  source                = "./modules/cluster"
-  cluster_name          = local.cluster_name
-  cluster_version       = var.cluster_version
-  desired_node_count    = var.desired_node_count
-  min_node_count        = var.min_node_count
-  max_node_count        = var.max_node_count
-  node_machine_type     = var.node_machine_type
-  spot_price            = var.spot_price
-  vpc_name              = var.vpc_name
-  vpc_subnets           = var.vpc_subnets
-  vpc_cidr_block        = var.vpc_cidr_block
-  force_destroy         = var.force_destroy
-  enable_spot_instances = var.enable_spot_instances
-  enable_node_group     = var.enable_node_group
-  enable_worker_group   = var.enable_worker_group
+  source                    = "./modules/cluster"
+  cluster_name              = local.cluster_name
+  cluster_version           = var.cluster_version
+  desired_node_count        = var.desired_node_count
+  min_node_count            = var.min_node_count
+  max_node_count            = var.max_node_count
+  node_machine_type         = var.node_machine_type
+  spot_price                = var.spot_price
+  vpc_name                  = var.vpc_name
+  public_subnets            = var.public_subnets
+  private_subnets           = var.private_subnets
+  vpc_cidr_block            = var.vpc_cidr_block
+  force_destroy             = var.force_destroy
+  enable_spot_instances     = var.enable_spot_instances
+  enable_node_group         = var.enable_node_group
+  enable_worker_group       = var.enable_worker_group
+  cluster_in_private_subnet = var.cluster_in_private_subnet
 }
 
 // ----------------------------------------------------------------------------

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -34,7 +34,8 @@ module "vpc" {
   name                 = var.vpc_name
   cidr                 = var.vpc_cidr_block
   azs                  = data.aws_availability_zones.available.names
-  public_subnets       = var.vpc_subnets
+  public_subnets       = var.public_subnets
+  private_subnets      = var.private_subnets
   enable_dns_hostnames = true
 
   tags = {
@@ -52,14 +53,14 @@ module "vpc" {
 // See https://github.com/terraform-aws-modules/terraform-aws-eks
 // ----------------------------------------------------------------------------
 module "eks" {
-  source          = "terraform-aws-modules/eks/aws"
-  version         = "12.1.0"
-  cluster_name    = var.cluster_name
-  cluster_version = var.cluster_version
-  subnets         = module.vpc.public_subnets
-  vpc_id          = module.vpc.vpc_id
-  enable_irsa     = true
-  worker_groups = var.enable_worker_group ? [
+  source           = "terraform-aws-modules/eks/aws"
+  version          = "12.1.0"
+  cluster_name     = var.cluster_name
+  cluster_version  = var.cluster_version
+  subnets          = (var.cluster_in_private_subnet ? module.vpc.private_subnets : module.vpc.public_subnets)
+  vpc_id           = module.vpc.vpc_id
+  enable_irsa      = true
+  worker_groups    = var.enable_worker_group ? [
     {
       name                 = "worker-group-${var.cluster_name}"
       instance_type        = var.node_machine_type

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -34,9 +34,14 @@ variable "vpc_name" {
   default = "tf-vpc-eks"
 }
 
-variable "vpc_subnets" {
-  type    = list(string)
-  default = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+variable "public_subnets" {
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+}
+
+variable "private_subnets" {
+  type        = list(string)
+  default     = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
 }
 
 variable "vpc_cidr_block" {
@@ -102,6 +107,12 @@ variable "force_destroy" {
 
 variable "enable_spot_instances" {
   description = "Flag to enable spot instances"
+  type        = bool
+  default     = false
+}
+
+variable "cluster_in_private_subnet" {
+  description = "Flag to enable installation of cluster on private subnets"
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -88,10 +88,16 @@ variable "vpc_name" {
   default     = "tf-vpc-eks"
 }
 
-variable "vpc_subnets" {
-  description = "The subnet CIDR block to use in the created VPC"
+variable "public_subnets" {
+  description = "The public subnet CIDR block to use in the created VPC"
   type        = list(string)
   default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+}
+
+variable "private_subnets" {
+  description = "The private subnet CIDR block to use in the created VPC"
+  type        = list(string)
+  default     = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
 }
 
 variable "vpc_cidr_block" {
@@ -194,4 +200,10 @@ variable "enable_key_rotation" {
   description = "Flag to enable kms key rotation"
   type        = bool
   default     = true
+}
+
+variable "cluster_in_private_subnet" {
+  description = "Flag to enable installation of cluster on private subnets"
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
For security purposes, the worker nodes should be on a private subnet by default. 

The example EKS module places the workers on the private subnet.
```
module "eks" {
  source       = "../.."
  cluster_name = local.cluster_name
  subnets      = module.vpc.private_subnets
```
Due to lack of private subnet definition it is placed on the defined public subnet.

fixes #88