### PR TITLE
feat: using on-demand as default billing for dynamodb

### DIFF
--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -49,9 +49,9 @@ resource "aws_dynamodb_table" "vault-dynamodb-table" {
   count = var.external_vault ? 0 : 1 
 
   name           = "vault-unseal-${var.cluster_name}-${local.vault_seed}"
-  billing_mode   = "PROVISIONED"
-  read_capacity  = 2
-  write_capacity = 2
+  billing_mode   = (var.enable_provisioned_dynamodb ? "PROVISIONED" : "PAY_PER_REQUEST")
+  read_capacity  = var.billing_rcu
+  write_capacity = var.billing_wcu
   hash_key       = "Path"
   range_key      = "Key"
 

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -34,3 +34,25 @@ variable "external_vault" {
   type        = bool
   default     = false
 }
+
+// ----------------------------------------------------------------------------
+// DynamoDB Variables
+// ----------------------------------------------------------------------------
+
+variable "billing_rcu" {
+  description = "The Read Capacity Units of DynamoDB when using PROVISIONED"
+  type        = number
+  default     = 2
+}
+
+variable "billing_wcu" {
+  description = "The Write Capacity Units of DynamoDB when using PROVISIONED"
+  type        = number
+  default     = 2
+}
+
+variable "enable_provisioned_dynamodb" {
+  description = "Flag to enable provisioned billing for DynamoDB"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
The Free Tier for DynamoDB is On-Demand 25 Read Capacity Units and 25 Write Capacity Units. This is used as the default. The old setting is available as an option which is Provisioned with 2 RCU and 2 WCU is set as default.

fixes #86 