### PR TITLE
feat: expose eks module's aws_auth mappers

### DIFF
--- a/examples/dev-team/main.tf
+++ b/examples/dev-team/main.tf
@@ -1,0 +1,15 @@
+module "jx-eks" {
+    source                 = "jenkins-x/eks-jx/aws"
+    map_users = [
+		{
+			userarn  = aws_iam_user.alice.arn
+			username = aws_iam_user.alice.name
+			groups   = ["system:masters"]
+		},
+		{
+			userarn  = aws_iam_user.bob.arn
+			username = aws_iam_user.bob.name
+			groups   = ["system:masters"]
+		}
+	]
+}

--- a/examples/dev-team/outputs.tf
+++ b/examples/dev-team/outputs.tf
@@ -1,0 +1,4 @@
+output "jx_requirements" {
+  value = module.eks-jx.jx_requirements
+  description = "The templated jx-requirements.yml"
+} 

--- a/examples/dev-team/user-alice.tf
+++ b/examples/dev-team/user-alice.tf
@@ -1,0 +1,24 @@
+resource "aws_iam_user" "alice" {
+  name = "alice"
+}
+
+resource "aws_iam_access_key" "alice" {
+  user = aws_iam_user.alice.name
+}
+
+output "alice_aws_iam_user_arn" {
+  value       = aws_iam_user.alice.arn
+  description = "IAM ARN for alice"
+}
+
+output "alice_aws_access_key_id" {
+  value       = aws_iam_access_key.alice.id
+  description = "IAM Access Key ID for alice"
+}
+
+output "alice_aws_secret_access_key" {
+  value       = aws_iam_access_key.alice.secret
+  description = "IAM Secret Access Key for alice"
+}
+
+

--- a/examples/dev-team/user-bob.tf
+++ b/examples/dev-team/user-bob.tf
@@ -1,0 +1,24 @@
+resource "aws_iam_user" "bob" {
+  name = "bob"
+}
+
+resource "aws_iam_access_key" "bob" {
+  user = aws_iam_user.bob.name
+}
+
+output "bob_aws_iam_user_arn" {
+  value       = aws_iam_user.bob.arn
+  description = "IAM ARN for bob"
+}
+
+output "bob_aws_access_key_id" {
+  value       = aws_iam_access_key.bob.id
+  description = "IAM Access Key ID for bob"
+}
+
+output "bob_aws_secret_access_key" {
+  value       = aws_iam_access_key.bob.secret
+  description = "IAM Secret Access Key for bob"
+}
+
+

--- a/examples/dev-team/user-group-developers.tf
+++ b/examples/dev-team/user-group-developers.tf
@@ -1,0 +1,35 @@
+resource "aws_iam_group" "developers" {
+  name = "developers"
+  path = "/users/"
+}
+
+resource "aws_iam_group_membership" "developers" {
+  name = "developers"
+
+  users = [
+    aws_iam_user.alice.name,
+    aws_iam_user.bob.name,
+  ]
+
+  group = aws_iam_group.developers.name
+}
+
+resource "aws_iam_group_policy" "developers" {
+  name  = "developers"
+  group = aws_iam_group.developers.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "eks:*"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}

--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,9 @@ module "cluster" {
   node_group_disk_size      = var.node_group_disk_size
   enable_worker_group       = var.enable_worker_group
   cluster_in_private_subnet = var.cluster_in_private_subnet
+  map_accounts              = var.map_accounts
+  map_roles                 = var.map_roles
+  map_users                 = var.map_users
 }
 
 // ----------------------------------------------------------------------------

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -106,6 +106,10 @@ module "eks" {
     }
   } : {}
 
+  map_users       = var.map_users
+  map_roles       = var.map_roles
+  map_accounts    = var.map_accounts
+
 }
 
 // ----------------------------------------------------------------------------

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -116,3 +116,29 @@ variable "cluster_in_private_subnet" {
   type        = bool
   default     = false
 }
+
+variable "map_accounts" {
+  description = "Additional AWS account numbers to add to the aws-auth configmap."
+  type        = list(string)
+  default = []
+}
+
+variable "map_roles" {
+  description = "Additional IAM roles to add to the aws-auth configmap."
+  type = list(object({
+    rolearn  = string
+    username = string
+    groups   = list(string)
+  }))
+  default = []
+}
+
+variable "map_users" {
+  description = "Additional IAM users to add to the aws-auth configmap."
+  type = list(object({
+    userarn  = string
+    username = string
+    groups   = list(string)
+  }))
+  default = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -207,3 +207,32 @@ variable "cluster_in_private_subnet" {
   type        = bool
   default     = false
 }
+
+// ----------------------------------------------------------------------------
+// Cluster AWS Auth Variables
+// ----------------------------------------------------------------------------
+variable "map_accounts" {
+  description = "Additional AWS account numbers to add to the aws-auth configmap."
+  type        = list(string)
+  default     = []
+}
+
+variable "map_roles" {
+  description = "Additional IAM roles to add to the aws-auth configmap."
+  type = list(object({
+    rolearn  = string
+    username = string
+    groups   = list(string)
+  }))
+  default = []
+}
+
+variable "map_users" {
+  description = "Additional IAM users to add to the aws-auth configmap."
+  type = list(object({
+    userarn  = string
+    username = string
+    groups   = list(string)
+  }))
+  default = []
+}


### PR DESCRIPTION
<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description

Adds ability to set aws_auth mapper variables - `map_users`, `map_accounts`, and `map_roles`

Example:
```
resource "aws_iam_user" "patrick" {
  name = "patrick"
}

module "eks-jx" {
  source  = "jenkins-x/eks-jx/aws"
  map_users = [
    {
      userarn  = aws_iam_user.patrick.arn
      username = aws_iam_user.patrick.name
      groups   = ["system:masters"]
    }
  ]
}
```

Here is a terraform plan, just with ARN's edited and replaced with "XXX"

```
> terraform plan

# module.eks-jx.module.cluster.module.eks.kubernetes_config_map.aws_auth[0] will be updated in-place
  ~ resource "kubernetes_config_map" "aws_auth" {
        binary_data = {}
      ~ data        = {
            "mapAccounts" = jsonencode([])
            "mapRoles"    = <<~EOT
                - "groups":
                  - "system:bootstrappers"
                  - "system:nodes"
                  "rolearn": "arn:aws:iam::XXX:role/project-eks-XXX"
                  "username": "system:node:{{EC2PrivateDNSName}}"
            EOT
          ~ "mapUsers"    = <<~EOT
              - - userarn: arn:aws:iam::XXX:user/patrick
              -   username: patrick
              -   groups:
              -     - system:masters
              + - "groups":
              +   - "system:masters"
              +   "userarn": "arn:aws:iam::XXX:user/patrick"
              +   "username": "patrick"
            EOT
        }
        id          = "kube-system/aws-auth"

        metadata {
            annotations      = {}
            generation       = 0
            labels           = {}
            name             = "aws-auth"
            namespace        = "kube-system"
            resource_version = "761148"
            self_link        = "/api/v1/namespaces/kube-system/configmaps/aws-auth"
            uid              = "6d2cbcac-d90c-4b33-89c2-b738b9c557c3"
        }
    }
```

#### Special notes for the reviewer(s)

Currently we are unable to add additional users to aws_auth because every terraform reapply will remove our customizations.

#### Which issue this PR fixes

fixes #29 
