### PR TITLE
fix: allow enduser to specify node group disk size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,9 @@ lint: init ## Verifies Terraform syntax
 fmt: ## Reformats Terraform files accoring to standard
 	terraform fmt
 
+# There is a bug in the latest version which causes a panic.
 $(TFSEC): bin ## Installs tfsec
-	curl -L "$$(curl -s https://api.github.com/repos/liamg/tfsec/releases/latest | grep -o -E "https://.+?-$(OS)-amd64(.exe)?")" > $(TFSEC);\
+	curl -L "$$(curl -s https://api.github.com/repos/liamg/tfsec/releases/tags/v0.21.0 | grep -o -E "https://.+?-$(OS)-amd64(.exe)?")" > $(TFSEC);\
 	chmod +x $(TFSEC)
 
 check-tfsec: ## Check if tfsec is installed
@@ -53,7 +54,7 @@ check-tfsec: ## Check if tfsec is installed
 
 .PHONY: tfsec
 tfsec: $(TFSEC) check-tfsec ## Runs tfsec
-	$(TFSEC) . -e AWS002,AWS017
+	$(TFSEC) -e AWS002,AWS017
 
 bin: ## Create bin directory for test binaries
 	mkdir bin

--- a/examples/backend/outputs.tf
+++ b/examples/backend/outputs.tf
@@ -1,7 +1,7 @@
 output "jx_requirements" {
-  value = module.eks-jx.jx_requirements
+  value       = module.eks-jx.jx_requirements
   description = "The templated jx-requirements.yml"
-} 
+}
 
 output "vault_user_id" {
   value       = module.eks-jx.vault_user_id

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -1,4 +1,4 @@
 output "jx_requirements" {
-  value = module.eks-jx.jx_requirements
+  value       = module.eks-jx.jx_requirements
   description = "The templated jx-requirements.yml"
-} 
+}

--- a/examples/nodegroup/outputs.tf
+++ b/examples/nodegroup/outputs.tf
@@ -1,4 +1,4 @@
 output "jx_requirements" {
-  value = module.eks-jx.jx_requirements
+  value       = module.eks-jx.jx_requirements
   description = "The templated jx-requirements.yml"
-} 
+}

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,7 @@ module "cluster" {
   force_destroy             = var.force_destroy
   enable_spot_instances     = var.enable_spot_instances
   enable_node_group         = var.enable_node_group
+  node_group_disk_size      = var.node_group_disk_size
   enable_worker_group       = var.enable_worker_group
   cluster_in_private_subnet = var.cluster_in_private_subnet
 }

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -53,14 +53,14 @@ module "vpc" {
 // See https://github.com/terraform-aws-modules/terraform-aws-eks
 // ----------------------------------------------------------------------------
 module "eks" {
-  source           = "terraform-aws-modules/eks/aws"
-  version          = "12.1.0"
-  cluster_name     = var.cluster_name
-  cluster_version  = var.cluster_version
-  subnets          = (var.cluster_in_private_subnet ? module.vpc.private_subnets : module.vpc.public_subnets)
-  vpc_id           = module.vpc.vpc_id
-  enable_irsa      = true
-  worker_groups    = var.enable_worker_group ? [
+  source          = "terraform-aws-modules/eks/aws"
+  version         = "12.1.0"
+  cluster_name    = var.cluster_name
+  cluster_version = var.cluster_version
+  subnets         = (var.cluster_in_private_subnet ? module.vpc.private_subnets : module.vpc.public_subnets)
+  vpc_id          = module.vpc.vpc_id
+  enable_irsa     = true
+  worker_groups = var.enable_worker_group ? [
     {
       name                 = "worker-group-${var.cluster_name}"
       instance_type        = var.node_machine_type

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -35,13 +35,13 @@ variable "vpc_name" {
 }
 
 variable "public_subnets" {
-  type        = list(string)
-  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  type    = list(string)
+  default = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
 }
 
 variable "private_subnets" {
-  type        = list(string)
-  default     = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  type    = list(string)
+  default = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
 }
 
 variable "vpc_cidr_block" {

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -17,7 +17,7 @@ resource "aws_iam_access_key" "jenkins-x-vault" {
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_user" "vault_user" {
-  count = var.external_vault ? 0 : 1 
+  count = var.external_vault ? 0 : 1
 
   user_name  = var.vault_user == "" ? aws_iam_user.jenkins-x-vault[0].name : var.vault_user
   depends_on = [aws_iam_user.jenkins-x-vault]
@@ -28,7 +28,7 @@ data "aws_iam_user" "vault_user" {
 // See https://www.terraform.io/docs/providers/aws/r/s3_bucket.html
 // ----------------------------------------------------------------------------
 resource "aws_s3_bucket" "vault-unseal-bucket" {
-  count = var.external_vault ? 0 : 1 
+  count = var.external_vault ? 0 : 1
 
   bucket_prefix = "vault-unseal-${var.cluster_name}-"
   acl           = "private"
@@ -46,7 +46,7 @@ resource "aws_s3_bucket" "vault-unseal-bucket" {
 // See https://www.terraform.io/docs/providers/aws/r/dynamodb_table.html
 // ----------------------------------------------------------------------------
 resource "aws_dynamodb_table" "vault-dynamodb-table" {
-  count = var.external_vault ? 0 : 1 
+  count = var.external_vault ? 0 : 1
 
   name           = "vault-unseal-${var.cluster_name}-${local.vault_seed}"
   billing_mode   = (var.enable_provisioned_dynamodb ? "PROVISIONED" : "PAY_PER_REQUEST")
@@ -75,11 +75,11 @@ resource "aws_dynamodb_table" "vault-dynamodb-table" {
 // See https://www.terraform.io/docs/providers/aws/r/kms_key.html
 // ----------------------------------------------------------------------------
 resource "aws_kms_key" "kms_vault_unseal" {
-  count = var.external_vault ? 0 : 1 
+  count = var.external_vault ? 0 : 1
 
-  description = "KMS Key for bank vault unseal"
+  description         = "KMS Key for bank vault unseal"
   enable_key_rotation = var.enable_key_rotation
-  policy      = <<POLICY
+  policy              = <<POLICY
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -106,7 +106,7 @@ POLICY
 // against AWS
 // ----------------------------------------------------------------------------
 data "aws_iam_policy_document" "vault_iam_user_policy_document" {
-  count = var.external_vault ? 0 : 1 
+  count = var.external_vault ? 0 : 1
 
   depends_on = [
     aws_dynamodb_table.vault-dynamodb-table,
@@ -178,7 +178,7 @@ data "aws_iam_policy_document" "vault_iam_user_policy_document" {
 }
 
 resource "aws_iam_policy" "aws_vault_user_policy" {
-  count = var.external_vault ? 0 : 1 
+  count = var.external_vault ? 0 : 1
 
   name_prefix = "vault_${var.region}-"
   description = "Vault Policy for the provided IAM User"
@@ -186,7 +186,7 @@ resource "aws_iam_policy" "aws_vault_user_policy" {
 }
 
 resource "aws_iam_user_policy_attachment" "attach_vault_policy_to_user" {
-  count = var.external_vault ? 0 : 1 
+  count = var.external_vault ? 0 : 1
 
   user       = data.aws_iam_user.vault_user[0].user_name
   policy_arn = aws_iam_policy.aws_vault_user_policy[0].arn

--- a/modules/vault/outputs.tf
+++ b/modules/vault/outputs.tf
@@ -3,34 +3,34 @@
 // The created KMS Key ID
 // ----------------------------------------------------------------------------
 output "kms_vault_unseal" {
-    value = length(aws_kms_key.kms_vault_unseal) > 0 ? aws_kms_key.kms_vault_unseal[0].id : ""
-    
+  value = length(aws_kms_key.kms_vault_unseal) > 0 ? aws_kms_key.kms_vault_unseal[0].id : ""
+
 }
 
 // ----------------------------------------------------------------------------
 // The created S3 Bucket ID
 // ----------------------------------------------------------------------------
 output "vault_unseal_bucket" {
-    value = length(aws_s3_bucket.vault-unseal-bucket) > 0 ? aws_s3_bucket.vault-unseal-bucket[0].id : ""
+  value = length(aws_s3_bucket.vault-unseal-bucket) > 0 ? aws_s3_bucket.vault-unseal-bucket[0].id : ""
 }
 
 // ----------------------------------------------------------------------------
 // The created DynamoDB ID
 // ----------------------------------------------------------------------------
 output "vault_dynamodb_table" {
-    value = length(aws_dynamodb_table.vault-dynamodb-table) > 0 ? aws_dynamodb_table.vault-dynamodb-table[0].id : ""
+  value = length(aws_dynamodb_table.vault-dynamodb-table) > 0 ? aws_dynamodb_table.vault-dynamodb-table[0].id : ""
 }
 
 // ----------------------------------------------------------------------------
 // The Vault user id if one got created
 // ----------------------------------------------------------------------------
 output "vault_user_id" {
-  value =  var.vault_user == "" ? aws_iam_access_key.jenkins-x-vault.*.id : []
+  value = var.vault_user == "" ? aws_iam_access_key.jenkins-x-vault.*.id : []
 }
 
 // ----------------------------------------------------------------------------
 // The Vault user secret if one got created
 // ----------------------------------------------------------------------------
 output "vault_user_secret" {
-  value =  var.vault_user == "" ? aws_iam_access_key.jenkins-x-vault.*.secret : []
+  value = var.vault_user == "" ? aws_iam_access_key.jenkins-x-vault.*.secret : []
 }


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

#### Submitter checklist

- [x] Change is code complete and matches issue description.
- [x] Change is covered by existing or new tests.
- [x] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 

#### Description
We already had a variable to specify the size of the disks used by the eks node group nodes, but it was never passed to the cluster module. This PR fixes that.

The latest version of tfsec panics, and breaks the checks. This PR pins the version of tfsec to v0.21.0

#### Special notes for the reviewer(s)
It's a bit weird that the master branch had code which was not formatted. 

#### Which issue this PR fixes

fixes #105 
