### PR TITLE
feat: cluster autoscaler - fixes #135

### DIFF
--- a/modules/cluster/irsa.tf
+++ b/modules/cluster/irsa.tf
@@ -245,3 +245,65 @@ resource "kubernetes_service_account" "jenkins-x-controllerbuild" {
     ]
   }
 }
+
+// ----------------------------------------------------------------------------
+// Cluster Autoscaler
+// ----------------------------------------------------------------------------
+
+module "iam_assumable_role_cluster_autoscaler" {
+  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                       = "~> v2.13.0"
+  create_role                   = true
+  role_name                     = "tf-${var.cluster_name}-cluster-autoscaler"
+  provider_url                  = local.oidc_provider_url
+  role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:cluster-autoscaler"]
+}
+
+resource "aws_iam_policy" "cluster_autoscaler" {
+  name_prefix = "cluster-autoscaler"
+  description = "EKS cluster-autoscaler policy for cluster ${module.eks.cluster_id}"
+  policy      = data.aws_iam_policy_document.cluster_autoscaler.json
+}
+
+data "aws_iam_policy_document" "cluster_autoscaler" {
+  statement {
+    sid    = "clusterAutoscalerAll"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeTags",
+      "ec2:DescribeLaunchTemplateVersions",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "clusterAutoscalerOwn"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "autoscaling:UpdateAutoScalingGroup",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "autoscaling:ResourceTag/kubernetes.io/cluster/${module.eks.cluster_id}"
+      values   = ["owned"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled"
+      values   = ["true"]
+    }
+  }
+}

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -53,3 +53,8 @@ output "controllerbuild_iam_role" {
   value       = module.iam_assumable_role_controllerbuild
   description = "The IAM Role that the ControllerBuild pod will assume to authenticate"
 }
+
+output "cluster_autoscaler_iam_role" {
+  value       = module.iam_assumable_role_cluster_autoscaler
+  description = "The IAM Role that the Cluster Autoscaler pod will assume to authenticate"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -65,6 +65,11 @@ output "controllerbuild_iam_role" {
   description = "The IAM Role that the ControllerBuild pod will assume to authenticate"
 }
 
+output "cluster_autoscaler_iam_role" {
+  value       = module.cluster.cluster_autoscaler_iam_role
+  description = "The IAM Role that the Jenkins X UI pod will assume to authenticate"
+}
+
 // ----------------------------------------------------------------------------
 // Vault Resources
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
#### Description

This does not automatically install cluster-autoscaler, it installs all of the prerequisite policies and roles required to install autoscaler. The actual autoscaler installation varies depending on what version of kubernetes you are using.

This is probably possible to automate with the helm provider and some refactoring, but that can be a separate endeavor.

To install cluster autoscaler see README.md

fixes #135 
