### PR TITLE
docs: Add aws-cli as prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ You need the following binaries locally installed and configured on your _PATH_:
 
 - `terraform` (=> 0.12.17, < 0.14.0)
 - `kubectl` (>=1.10)
+- `aws-cli`
 - `aws-iam-authenticator`
 - `wget`
 


### PR DESCRIPTION
<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [X] Change is code complete and matches issue description.
- [X] Change is covered by existing or new tests.
- [X] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->

#### Description
Adds aws-cli as a listed dependency for the module installation. As noted in the issue, the module fails to apply unless the aws-cli is available and configured.

```
module.eks_jx.module.cluster.null_resource.kubeconfig (local-exec): Executing: ["/bin/bash" "-c" "aws eks update-kubeconfig --name tf-jx-helping-wren"]
module.eks_jx.module.cluster.null_resource.kubeconfig (local-exec): /bin/bash: aws: command not found


Error: Error running command 'aws eks update-kubeconfig --name tf-jx-helping-wren': exit status 127. Output: /bin/bash: aws: command not found
```

#### Special notes for the reviewer(s)

Opened here as a recommendation from the [original issue in the jx repo](https://github.com/jenkins-x/jx/issues/7532) 

#### Which issue this PR fixes

fixes #134
