### PR TITLE
feat: expose cluster oidc issuer url - fixes #150

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ The following sections provide a full list of configuration in- and output varia
 | backup\_bucket\_url | The bucket where backups from velero will be stored |
 | cert\_manager\_iam\_role | The IAM Role that the Cert Manager pod will assume to authenticate |
 | cluster\_name | The name of the created cluster |
+| cluster\_oidc\_issuer\_url | The Cluster OIDC Issuer URL |
 | cm\_cainjector\_iam\_role | The IAM Role that the CM CA Injector pod will assume to authenticate |
 | connect | "The cluster connection string to use once Terraform apply finishes,<br>this command is already executed as part of the apply, you may have to provide the region and<br>profile as environment variables " |
 | controllerbuild\_iam\_role | The IAM Role that the ControllerBuild pod will assume to authenticate |

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,6 +37,12 @@ output "cluster_name" {
   description = "The name of the created cluster"
 }
 
+output "cluster_oidc_issuer_url" {
+  value       = module.cluster.cluster_oidc_issuer_url
+  description = "The Cluster OIDC Issuer URL"
+}
+
+
 // ----------------------------------------------------------------------------
 // Generated IAM Roles
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description

Allows user to reuse cluster oidc issuer url

For example in setting up knative with auto tls injection.
