### PR TITLE
fix: fixed deprecate

### DIFF
--- a/modules/cluster/local.tf
+++ b/modules/cluster/local.tf
@@ -10,6 +10,6 @@ locals {
   generated_seed         = random_string.suffix.result
   oidc_provider_url      = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
   jenkins-x-namespace    = "jx"
-  cluster_trunc          = substr("${var.cluster_name}", 0, 40)
+  cluster_trunc          = substr(var.cluster_name, 0, 40)
   cert-manager-namespace = "cert-manager"
 }


### PR DESCRIPTION
<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description

Just edit the old Terraform variable style that was deprecated at the submodule cluster.
remove the `"${ sequence from the start and the }"`

#### Special notes for the reviewer(s)


#### Which issue this PR fixes
Warning: Interpolation-only expressions are deprecated
fixes: #190
