### PR TITLE
feat: disable vault resource creation if vault is not used

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ The following sections provide a full list of configuration in- and output varia
 | spot\_price | The spot price ceiling for spot instances | `string` | `"0.1"` | no |
 | subdomain | The subdomain to be added to the apex domain. If subdomain is set, it will be appended to the apex domain in  `jx-requirements-eks.yml` file | `string` | `""` | no |
 | tls\_email | The email to register the LetsEncrypt certificate with. Added to the `jx-requirements.yml` file | `string` | `""` | no |
+| use\_asm | Flag to specify if AWS Secrets manager is being used | `bool` | `false` | no |
 | use\_kms\_s3 | Flag to determine whether kms should be used for encrypting s3 buckets | `bool` | `false` | no |
+| use\_vault | Flag to control vault resource creation | `bool` | `true` | no |
 | vault\_url | URL to an external Vault instance in case Jenkins X does not create its own system Vault | `string` | `""` | no |
 | vault\_user | The AWS IAM Username whose credentials will be used to authenticate the Vault pods against AWS | `string` | `""` | no |
 | velero\_namespace | Kubernetes namespace for Velero | `string` | `"velero"` | no |
@@ -310,14 +312,18 @@ This allows you to remove all generated buckets when running terraform destroy.
 
 :warning: **Note**: If you set `force_destroy` to false, and run a `terraform destroy`, it will fail. In that case empty the s3 buckets from the aws s3 console, and re run `terraform destroy`.
 
-### Vault
+### Secrets Management
 
-Vault is used by Jenkins X for managing secrets.
+Vault is the default tool used by Jenkins X for managing secrets.
 Part of this module's responsibilities is the creation of all resources required to run the [Vault Operator](https://github.com/banzaicloud/bank-vaults).
 These resources are An S3 Bucket, a DynamoDB Table and a KMS Key.
 
 You can also configure an existing Vault instance for use with Jenkins X.
-In this case provide the Vault URL via the _vault_url_  input variable and follow the Jenkins X documentation around the instllation of an [external Vault](https://jenkins-x.io/docs/install-setup/installing/boot/secrets/#external) instance.
+In this case provide the Vault URL via the _vault_url_  input variable and follow the Jenkins X documentation around the installation of an [external Vault](https://jenkins-x.io/docs/install-setup/installing/boot/secrets/#external) instance.
+
+To use other secret backends such as AWS Secrets Manager, set `use_vault` variable to false, and `use_asm` variable to true.
+
+:warning: **Note**: AWS Secrets Manager is not supported yet, but will be functional soon. The `use_asm` just sets the `secretStorage` to `asm` instead of vault for now.
 
 ### ExternalDNS
 

--- a/examples/asm/main.tf
+++ b/examples/asm/main.tf
@@ -1,0 +1,8 @@
+module "eks-jx" {
+  source          = "../../"
+  region          = var.region
+  use_vault       = var.use_vault
+  use_asm         = var.use_asm
+  is_jx2          = false
+  cluster_version = "1.18"
+}

--- a/examples/asm/outputs.tf
+++ b/examples/asm/outputs.tf
@@ -1,0 +1,89 @@
+// Vault
+output "vault_user_id" {
+  value       = module.eks-jx.vault_user_id
+  description = "The Vault IAM user id"
+}
+
+output "vault_user_secret" {
+  value       = module.eks-jx.vault_user_secret
+  description = "The Vault IAM user secret"
+}
+
+output "vault_unseal_bucket" {
+  value       = module.eks-jx.vault_unseal_bucket
+  description = "The Vault storage bucket"
+}
+
+output "vault_dynamodb_table" {
+  value       = module.eks-jx.vault_dynamodb_table
+  description = "The Vault DynamoDB table"
+}
+
+output "vault_kms_unseal" {
+  value       = module.eks-jx.vault_kms_unseal
+  description = "The Vault KMS Key for encryption"
+}
+
+
+// Storage (backup, logs, reports, repo)
+output "backup_bucket_url" {
+  value       = module.eks-jx.backup_bucket_url
+  description = "The bucket where backups from velero will be stored"
+}
+
+output "lts_logs_bucket" {
+  value       = module.eks-jx.lts_logs_bucket
+  description = "The bucket where logs from builds will be stored"
+}
+
+output "lts_reports_bucket" {
+  value       = module.eks-jx.lts_reports_bucket
+  description = "The bucket where test reports will be stored"
+}
+
+output "lts_repository_bucket" {
+  value       = module.eks-jx.lts_reports_bucket
+  description = "The bucket that will serve as artifacts repository"
+}
+
+// IAM Roles
+output "cert_manager_iam_role" {
+  value       = module.eks-jx.cert_manager_iam_role
+  description = "The IAM Role that the Cert Manager pod will assume to authenticate"
+}
+
+output "tekton_bot_iam_role" {
+  value       = module.eks-jx.tekton_bot_iam_role
+  description = "The IAM Role that the build pods will assume to authenticate"
+}
+
+output "external_dns_iam_role" {
+  value       = module.eks-jx.external_dns_iam_role
+  description = "The IAM Role that the External DNS pod will assume to authenticate"
+}
+
+output "cm_cainjector_iam_role" {
+  value       = module.eks-jx.cm_cainjector_iam_role
+  description = "The IAM Role that the CM CA Injector pod will assume to authenticate"
+}
+
+output "controllerbuild_iam_role" {
+  value       = module.eks-jx.controllerbuild_iam_role
+  description = "The IAM Role that the ControllerBuild pod will assume to authenticate"
+}
+
+output "cluster_autoscaler_iam_role" {
+  value       = module.eks-jx.cluster_autoscaler_iam_role
+  description = "The IAM Role that the Jenkins X UI pod will assume to authenticate"
+}
+
+// Cluster specific output
+output "cluster_name" {
+  value       = module.eks-jx.cluster_name
+  description = "The name of the created cluster"
+}
+
+output "cluster_oidc_issuer_url" {
+  value       = module.eks-jx.cluster_oidc_issuer_url
+  description = "The Cluster OIDC Issuer URL"
+}

--- a/examples/asm/variables.tf
+++ b/examples/asm/variables.tf
@@ -1,0 +1,14 @@
+variable "region" {
+  type    = string
+  default = "us-east-2"
+}
+
+variable "use_vault" {
+  type    = bool
+  default = false
+}
+
+variable "use_asm" {
+  type    = bool
+  default = true
+}

--- a/local.tf
+++ b/local.tf
@@ -26,6 +26,9 @@ locals {
     vault_user           = var.vault_user
     vault_url            = var.vault_url
     external_vault       = local.external_vault
+    use_vault            = var.use_vault
+    // AWS Secrets Manager
+    use_asm = var.use_asm
     // Velero
     enable_backup     = var.enable_backup
     backup_bucket_url = module.backup.backup_bucket_url

--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,7 @@ module "vault" {
   vault_user     = var.vault_user
   force_destroy  = var.force_destroy
   external_vault = local.external_vault
+  use_vault      = var.use_vault
 }
 
 // ----------------------------------------------------------------------------

--- a/modules/vault/local.tf
+++ b/modules/vault/local.tf
@@ -8,5 +8,6 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  vault_seed = random_string.suffix.result
+  vault_seed             = random_string.suffix.result
+  create_vault_resources = var.use_vault && ! var.external_vault
 }

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -73,3 +73,9 @@ variable "is_jx2" {
   default = true
   type    = bool
 }
+
+variable "use_vault" {
+  description = "Flag to control vault resource creation"
+  type        = bool
+  default     = true
+}

--- a/templates/jx-requirements.yml.tpl
+++ b/templates/jx-requirements.yml.tpl
@@ -23,6 +23,7 @@ ingress:
     enabled: ${enable_tls}
     production: ${use_production_letsencrypt}
 kaniko: true
+%{ if use_vault }
 secretStorage: vault
 vault:
 %{ if external_vault }
@@ -36,6 +37,10 @@ vault:
     kmsRegion: "${region}"
     s3Bucket: "${vault_bucket}"
     s3Region: "${region}"
+%{ endif }
+%{ endif }
+%{ if use_asm }
+secretStorage: asm
 %{ endif }
 %{ if enable_backup }
 velero:

--- a/variables.tf
+++ b/variables.tf
@@ -412,3 +412,15 @@ variable "create_vpc" {
   type        = bool
   default     = true
 }
+
+variable "use_vault" {
+  description = "Flag to control vault resource creation"
+  type        = bool
+  default     = true
+}
+
+variable "use_asm" {
+  description = "Flag to specify if AWS Secrets manager is being used"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

#### Special notes for the reviewer(s)
The `use_asm` does not add any support for AWS Secrets Manager yet, just sets the `secretStorage` value to `asm` instead of vault in the `jx-requirements` template.

#### Which issue this PR fixes

fixes #183 
