### PR TITLE
feat: custom velero username

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ The following sections provide a full list of configuration in- and output varia
 | velero\_namespace | Kubernetes namespace for Velero | `string` | `"velero"` | no |
 | velero\_schedule | The Velero backup schedule in cron notation to be set in the Velero Schedule CRD (see [default-backup.yaml](https://github.com/jenkins-x/jenkins-x-boot-config/blob/master/systems/velero-backups/templates/default-backup.yaml)) | `string` | `"0 * * * *"` | no |
 | velero\_ttl | The the lifetime of a velero backup to be set in the Velero Schedule CRD (see [default-backup.yaml](https://github.com/jenkins-x/jenkins-x-boot-config/blob/master/systems/velero-backups/templates/default-backup)) | `string` | `"720h0m0s"` | no |
+| velero\_username | The username to be assigned to the Velero IAM user | `string` | `"velero"` | no |
 | volume\_size | The volume size in GB | `number` | `50` | no |
 | volume\_type | The volume type to use. Can be standard, gp2 or io1 | `string` | `"gp2"` | no |
 | vpc\_cidr\_block | The vpc CIDR block | `string` | `"10.0.0.0/16"` | no |

--- a/main.tf
+++ b/main.tf
@@ -96,9 +96,10 @@ module "vault" {
 module "backup" {
   source = "./modules/backup"
 
-  enable_backup = var.enable_backup
-  cluster_name  = local.cluster_name
-  force_destroy = var.force_destroy
+  enable_backup   = var.enable_backup
+  cluster_name    = local.cluster_name
+  force_destroy   = var.force_destroy
+  velero_username = var.velero_username
 }
 
 // ----------------------------------------------------------------------------

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -34,7 +34,7 @@ resource "aws_s3_bucket" "backup_bucket" {
 // ----------------------------------------------------------------------------
 resource "aws_iam_user" "velero" {
   count = var.enable_backup ? 1 : 0
-  name  = "velero"
+  name  = var.velero_username
 }
 
 resource "aws_iam_access_key" "velero" {

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -43,3 +43,10 @@ variable "is_jx2" {
   default = true
   type    = bool
 }
+
+variable "velero_username" {
+  description = "The username to be assigned to the Velero IAM user"
+  type        = string
+  default     = "velero"
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -61,6 +61,12 @@ variable "velero_ttl" {
   default     = "720h0m0s"
 }
 
+variable "velero_username" {
+  description = "The username to be assigned to the Velero IAM user"
+  type        = string
+  default     = "velero"
+}
+
 // ----------------------------------------------------------------------------
 // Worker Nodes Variables
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
#### Description

Allow for custom velero usernames to be passed as a variable to the module. This allows for multiple velero instances under the same AWS account, whereas previously it would cause an IAM username conflict.

Variable is optional and default will result in same outcome as currently expected - username of 'velero'.

#### Special notes for the reviewer(s)

None

#### Which issue this PR fixes

fixes #209 
