### PR TITLE
fix: add object access to visualizer policy

### DIFF
--- a/modules/cluster/irsa.tf
+++ b/modules/cluster/irsa.tf
@@ -326,7 +326,7 @@ data "aws_iam_policy_document" "pipelines-visualizer-policy" {
       "s3:Get*",
       "s3:List*",
     ]
-    resources = [aws_s3_bucket.logs_jenkins_x.*.arn[0]]
+    resources = [aws_s3_bucket.logs_jenkins_x.*.arn[0] , "${aws_s3_bucket.logs_jenkins_x.*.arn[0]}/*"]
   }
 }
 

--- a/modules/cluster/irsa.tf
+++ b/modules/cluster/irsa.tf
@@ -326,7 +326,7 @@ data "aws_iam_policy_document" "pipelines-visualizer-policy" {
       "s3:Get*",
       "s3:List*",
     ]
-    resources = [aws_s3_bucket.logs_jenkins_x.*.arn[0] , "${aws_s3_bucket.logs_jenkins_x.*.arn[0]}/*"]
+    resources = [aws_s3_bucket.logs_jenkins_x.*.arn[0], "${aws_s3_bucket.logs_jenkins_x.*.arn[0]}/*"]
   }
 }
 


### PR DESCRIPTION
fix: add object access to visualizer policy

<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description
Give not only bucket access but also object access to the visualizer, or it will get no access to the logs:

status code: 403, request id: 6301D24E45EF1903, host id: Lqtrx39JLM289tl7UODgB2z3V53nGuxv7kLVNQse8qw7ZqmBfh/JIogNBcWGOuAyaj4dE83Fwpk=

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #
