### PR TITLE
fix: Adding helm

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -8,5 +8,6 @@ terraform {
     null       = "~> 2.1"
     template   = "~> 2.1"
     random     = "~> 2.1"
+    helm       = "~> 1.3.2"
   }
 }


### PR DESCRIPTION
On clean install, without adding the following to main.tf, it fails to create the cluster.
```
provider "helm" {
  version = "1.3.2"
}
```
It gives the following error:
```
module.eks-jx.module.cluster.helm_release.jx-git-operator[0]: Creating...
Error: provider not configured: you must configure a path to your kubeconfig
or explicitly supply credentials via the provider block or environment variables.
See our authentication documentation at: https://registry.terraform.io/providers/hashicorp/helm/latest/docs#authentication
```

After adding it to main.tf, it warns that adding provider in main.tf is deprecated, and it should be added to required providers instead, so here is the pull request.

<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #
