### PR TITLE
feat: allow additional policies to be passed to tekton IRSA role

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The following sections provide a full list of configuration in- and output varia
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| additional\_tekton\_role\_policy\_arns | Additional Policy ARNs to attach to Tekton IRSA Role | `list(string)` | `[]` | no |
 | allowed\_spot\_instance\_types | Allowed machine types for spot instances (must be same size) | `any` | `[]` | no |
 | apex\_domain | The main domain to either use directly or to configure a subdomain from | `string` | `""` | no |
 | cluster\_encryption\_config | Configuration block with encryption configuration for the cluster. | <pre>list(object({<br>    provider_key_arn = string<br>    resources        = list(string)<br>  }))</pre> | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -76,12 +76,14 @@ module "cluster" {
   jx_bot_token                          = var.jx_bot_token
   cluster_encryption_config             = var.cluster_encryption_config
   create_autoscaler_role                = var.create_autoscaler_role
+  create_bucketrepo_role                = var.create_bucketrepo_role
   create_cm_role                        = var.create_cm_role
   create_cmcainjector_role              = var.create_cmcainjector_role
   create_ctrlb_role                     = var.create_ctrlb_role
   create_exdns_role                     = var.create_exdns_role
   create_pipeline_vis_role              = var.create_pipeline_vis_role
   create_tekton_role                    = var.create_tekton_role
+  additional_tekton_role_policy_arns    = var.additional_tekton_role_policy_arns
 }
 
 // ----------------------------------------------------------------------------

--- a/modules/cluster/irsa.tf
+++ b/modules/cluster/irsa.tf
@@ -41,7 +41,7 @@ module "iam_assumable_role_tekton_bot" {
   create_role                   = var.create_tekton_role
   role_name                     = var.is_jx2 ? substr("tf-${var.cluster_name}-sa-role-tekton-bot-${local.generated_seed}", 0, 60) : "${local.cluster_trunc}-tekton-bot"
   provider_url                  = local.oidc_provider_url
-  role_policy_arns              = [aws_iam_policy.tekton-bot[0].arn]
+  role_policy_arns              = concat([aws_iam_policy.tekton-bot[0].arn], var.additional_tekton_role_policy_arns)
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.jenkins-x-namespace}:tekton-bot"]
 }
 resource "kubernetes_service_account" "tekton-bot" {

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -349,3 +349,9 @@ variable "create_bucketrepo_role" {
   type        = bool
   default     = true
 }
+
+variable "additional_tekton_role_policy_arns" {
+  description = "Additional Policy ARNs to attach to Tekton IRSA Role"
+  type        = list(string)
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -517,3 +517,9 @@ variable "create_bucketrepo_role" {
   type        = bool
   default     = true
 }
+
+variable "additional_tekton_role_policy_arns" {
+  description = "Additional Policy ARNs to attach to Tekton IRSA Role"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Signed-off-by: Patrick Lee Scott <pat@patscott.io>

Allows user to provide additional policy ARNs

For example, for `serverless deploy` permissions:

```
data "aws_iam_policy_document" "tekton-bot-policy-serverless" {
  statement {
    sid    = "tektonBotPolicyServerless"
    effect = "Allow"
    actions = [
      "cloudformation:*",
      "s3:*",
      "logs:*",
      "iam:*",
      "apigateway:*",
      "lambda:*",
      "ec2:DescribeSecurityGroups",
      "ec2:DescribeSubnets",
      "ec2:DescribeVpcs",
      "events:*",
      "sqs:*"
    ]
    resources = ["*"]
  }
}
resource "aws_iam_policy" "tekton-bot-serverless" {
  name_prefix = "jenkins-x-tekton-bot-serverless"
  description = "tekton-bot serverless deploy policy"
  policy      = data.aws_iam_policy_document.tekton-bot-policy-serverless.json
}

module "eks-0-jx" {
  source  = "jenkins-x/eks-jx/aws"
  version = "1.15.3"

  additional_tekton_role_policy_arns = [
    aws_iam_policy.tekton-bot-serverless.arn
  ]
}

```