### PR TITLE
fix: remove provider block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,6 @@
 // ----------------------------------------------------------------------------
 // Configure providers
 // ----------------------------------------------------------------------------
-provider "aws" {
-  region = var.region
-}
-
 provider "helm" {
   kubernetes {
     host                   = module.cluster.cluster_host


### PR DESCRIPTION
#### Description
Remove provider block from main.tf. This provider prohibits passing down a provider configuration from a parent terraform project, which makes it difficult to make this module work in multi-account environments where multiple providers are defined and used to assume various roles within the AWS org.

It is also recommended by the terraform documentation that a module intended to be used by other modules should not include provider configurations:
https://www.terraform.io/docs/language/modules/develop/providers.html
