### PR TITLE
EKS node groups overhaul

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,7 @@ module "cluster" {
   min_node_count                        = var.min_node_count
   max_node_count                        = var.max_node_count
   node_machine_type                     = var.node_machine_type
+  node_groups                           = var.node_groups_managed
   spot_price                            = var.spot_price
   encrypt_volume_self                   = var.encrypt_volume_self
   vpc_name                              = var.vpc_name

--- a/modules/cluster/local.tf
+++ b/modules/cluster/local.tf
@@ -12,4 +12,46 @@ locals {
   jenkins-x-namespace    = "jx"
   cluster_trunc          = substr(var.cluster_name, 0, 35)
   cert-manager-namespace = "cert-manager"
+
+  node_group_defaults = {
+    launch_template_id      = null
+    launch_template_version = null
+
+    # Provider default which is 'ON_DEMAND'. We don't set it explicitly to avoid changes to existing clusters provisioned with this module
+    capacity_type = var.enable_spot_instances ? "SPOT" : null
+
+    k8s_labels = {
+      "jenkins-x.io/name"       = var.cluster_name
+      "jenkins-x.io/part-of"    = "jx-platform"
+      "jenkins-x.io/managed-by" = "terraform"
+    }
+
+    additional_tags = {
+      aws_managed = "true"
+    }
+  }
+
+  node_groups_extended = length(var.node_groups) > 0 ? { for k, v in var.node_groups : k => merge(
+    local.node_group_defaults,
+    v,
+    {
+      # Deep merge isn't a thing in terraform, yet, so we commit these atrocities.
+      k8s_labels = merge(
+        local.node_group_defaults["k8s_labels"],
+        v["k8s_labels"],
+      )
+    },
+    ) } : {
+    eks-jx-node-group = merge(
+      {
+        ami_type         = var.node_group_ami
+        disk_size        = var.node_group_disk_size
+        desired_capacity = var.desired_node_count
+        max_capacity     = var.max_node_count
+        min_capacity     = var.min_node_count
+        instance_types   = [var.node_machine_type]
+      },
+      local.node_group_defaults
+    )
+  }
 }

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -123,25 +123,7 @@ module "eks" {
     }
   ] : []
 
-  node_groups = !var.enable_worker_group ? {
-    eks-jx-node-group = {
-      ami_type         = var.node_group_ami
-      disk_size        = var.node_group_disk_size
-      desired_capacity = var.desired_node_count
-      max_capacity     = var.max_node_count
-      min_capacity     = var.min_node_count
-
-      instance_type = var.node_machine_type
-      k8s_labels = {
-        "jenkins-x.io/name"       = var.cluster_name
-        "jenkins-x.io/part-of"    = "jx-platform"
-        "jenkins-x.io/managed-by" = "terraform"
-      }
-      additional_tags = {
-        aws_managed = "true"
-      }
-    }
-  } : {}
+  node_groups = !var.enable_worker_group ? local.node_groups_extended : {}
 
   workers_additional_policies = [
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -71,6 +71,22 @@ variable "spot_price" {
   default     = "0.1"
 }
 
+variable "node_groups" {
+  description = "List of node groups to be created"
+  type = map(object({
+    ami_type                = string
+    disk_size               = number
+    desired_capacity        = number
+    max_capacity            = number
+    min_capacity            = number
+    instance_types          = list(string)
+    launch_template_id      = string
+    launch_template_version = string
+    k8s_labels              = map(string)
+  }))
+  default = {}
+}
+
 variable "node_group_ami" {
   description = "ami type for the node group worker intances"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -112,6 +112,22 @@ variable "node_group_disk_size" {
   default     = "50"
 }
 
+variable "node_groups_managed" {
+  description = "List of managed node groups to be created and their respective settings"
+  type = map(object({
+    ami_type                = string
+    disk_size               = number
+    desired_capacity        = number
+    max_capacity            = number
+    min_capacity            = number
+    instance_types          = list(string)
+    launch_template_id      = string
+    launch_template_version = string
+    k8s_labels              = map(string)
+  }))
+  default = {}
+}
+
 variable "key_name" {
   description = "The ssh key pair name"
   type        = string


### PR DESCRIPTION
#### Description

This PR allows for compliant use of EKS node groups with the [terraform-aws-eks module](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/modules/node_groups) which results in instance settings being enforced.

Further, the changes also allow for overriding the default node group to allow for multiple node groups and the use of launch templates.

#### Special notes for the reviewer(s)

Introduces new input, 'node_groups_managed', for setting custom node groups.

#### Which issue this PR fixes

fixes #248 
