### PR TITLE
fix: prevent flip-flopping state by ignoring dynamodb capacity changes

### DIFF
--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -80,6 +80,13 @@ resource "aws_dynamodb_table" "vault-dynamodb-table" {
   tags = {
     Name = "vault-dynamo-db-table"
   }
+
+  lifecycle {
+    ignore_changes = [
+      read_capacity,
+      write_capacity
+    ]
+  }
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION

Such as described in https://github.com/hashicorp/terraform/issues/5617

Signed-off-by: Patrick Lee Scott <pat@patscott.io>

<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description

The tf module currently flip flops every plan and apply due to the dynamodb capacities changing. 

After:
```
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
Releasing state lock. This may take a few moments...
```
