### PR TITLE
feat: create service account for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ The following sections provide a full list of configuration in- and output varia
 | cluster\_name | Variable to provide your desired name for the cluster. The script will create a random name if this is empty | `string` | `""` | no |
 | cluster\_version | Kubernetes version to use for the EKS cluster. | `string` | n/a | yes |
 | create\_and\_configure\_subdomain | Flag to create an NS record set for the subdomain in the apex domain's Hosted Zone | `bool` | `false` | no |
+| create\_asm\_role | Flag to control AWS Secrets Manager iam roles creation | `bool` | `false` | no |
 | create\_autoscaler\_role | Flag to control cluster autoscaler iam role creation | `bool` | `true` | no |
 | create\_bucketrepo\_role | Flag to control bucketrepo role | `bool` | `true` | no |
 | create\_cm\_role | Flag to control cert manager iam role creation | `bool` | `true` | no |
@@ -167,6 +168,7 @@ The following sections provide a full list of configuration in- and output varia
 | create\_eks | Controls if EKS cluster and associated resources should be created or not. If you have an existing eks cluster for jx, set it to false | `bool` | `true` | no |
 | create\_exdns\_role | Flag to control external dns iam role creation | `bool` | `true` | no |
 | create\_pipeline\_vis\_role | Flag to control pipeline visualizer role | `bool` | `true` | no |
+| create\_ssm\_role | Flag to control AWS Parameter Store iam roles creation | `bool` | `false` | no |
 | create\_tekton\_role | Flag to control tekton iam role creation | `bool` | `true` | no |
 | create\_velero\_role | Flag to control velero iam role creation | `bool` | `true` | no |
 | create\_vpc | Controls if VPC and related resources should be created. If you have an existing vpc for jx, set it to false | `bool` | `true` | no |
@@ -237,9 +239,11 @@ The following sections provide a full list of configuration in- and output varia
 |------|-------------|
 | backup\_bucket\_url | The bucket where backups from velero will be stored |
 | cert\_manager\_iam\_role | The IAM Role that the Cert Manager pod will assume to authenticate |
+| cluster\_asm\_iam\_role | The IAM Role that the External Secrets pod will assume to authenticate (Secrets Manager) |
 | cluster\_autoscaler\_iam\_role | The IAM Role that the Jenkins X UI pod will assume to authenticate |
 | cluster\_name | The name of the created cluster |
 | cluster\_oidc\_issuer\_url | The Cluster OIDC Issuer URL |
+| cluster\_ssm\_iam\_role | The IAM Role that the External Secrets pod will assume to authenticate (Parameter Store) |
 | cm\_cainjector\_iam\_role | The IAM Role that the CM CA Injector pod will assume to authenticate |
 | connect | "The cluster connection string to use once Terraform apply finishes,<br>this command is already executed as part of the apply, you may have to provide the region and<br>profile as environment variables " |
 | controllerbuild\_iam\_role | The IAM Role that the ControllerBuild pod will assume to authenticate |

--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,8 @@ module "cluster" {
   create_ctrlb_role                     = var.create_ctrlb_role
   create_exdns_role                     = var.create_exdns_role
   create_pipeline_vis_role              = var.create_pipeline_vis_role
-  create_secrets_roles                  = var.create_secrets_roles
+  create_asm_role                       = var.create_asm_role
+  create_ssm_role                       = var.create_ssm_role
   create_tekton_role                    = var.create_tekton_role
   additional_tekton_role_policy_arns    = var.additional_tekton_role_policy_arns
 }

--- a/main.tf
+++ b/main.tf
@@ -87,6 +87,7 @@ module "cluster" {
   create_ctrlb_role                     = var.create_ctrlb_role
   create_exdns_role                     = var.create_exdns_role
   create_pipeline_vis_role              = var.create_pipeline_vis_role
+  create_secrets_role                   = var.create_secrets_role
   create_tekton_role                    = var.create_tekton_role
   additional_tekton_role_policy_arns    = var.additional_tekton_role_policy_arns
 }

--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,7 @@ module "cluster" {
   create_ctrlb_role                     = var.create_ctrlb_role
   create_exdns_role                     = var.create_exdns_role
   create_pipeline_vis_role              = var.create_pipeline_vis_role
-  create_secrets_role                   = var.create_secrets_role
+  create_secrets_roles                  = var.create_secrets_roles
   create_tekton_role                    = var.create_tekton_role
   additional_tekton_role_policy_arns    = var.additional_tekton_role_policy_arns
 }

--- a/modules/cluster/irsa.tf
+++ b/modules/cluster/irsa.tf
@@ -383,7 +383,7 @@ module "iam_assumable_role_bucketrepo" {
 // External Secrets - SecretsManager
 // ----------------------------------------------------------------------------
 data "aws_iam_policy_document" "secrets-manager-policy" {
-  count = var.create_secrets_roles ? 1 : 0
+  count = var.create_asm_role ? 1 : 0
   statement {
     effect = "Allow"
     actions = [
@@ -404,7 +404,7 @@ data "aws_iam_policy_document" "secrets-manager-policy" {
   }
 }
 resource "aws_iam_policy" "secrets-manager" {
-  count       = var.create_secrets_roles ? 1 : 0
+  count       = var.create_asm_role ? 1 : 0
   name_prefix = "jx-external-secrets-secrets-manager"
   description = "external-secrets policy for cluster ${var.cluster_name} for Secrets Manager ServiceAccount"
   policy      = data.aws_iam_policy_document.secrets-manager-policy[count.index].json
@@ -412,17 +412,17 @@ resource "aws_iam_policy" "secrets-manager" {
 module "iam_assumable_role_secrets-secrets-manager" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "~> v3.8.0"
-  create_role                   = var.create_secrets_roles
+  create_role                   = var.create_asm_role
   role_name                     = "${local.cluster_trunc}-external-secrets-secrets-manager"
   provider_url                  = local.oidc_provider_url
-  role_policy_arns              = [var.create_secrets_roles ? aws_iam_policy.secrets-manager[0].arn : ""]
+  role_policy_arns              = [var.create_asm_role ? aws_iam_policy.secrets-manager[0].arn : ""]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.jenkins-x-namespace}:external-secrets-secrets-manager"]
 }
 // ----------------------------------------------------------------------------
 // External Secrets - Parameter Store
 // ----------------------------------------------------------------------------
 data "aws_iam_policy_document" "parameter-store-policy" {
-  count = var.create_secrets_roles ? 1 : 0
+  count = var.create_ssm_role ? 1 : 0
   statement {
     effect = "Allow"
     actions = [
@@ -444,7 +444,7 @@ data "aws_iam_policy_document" "parameter-store-policy" {
 }
 
 resource "aws_iam_policy" "parameter-store" {
-  count       = var.create_secrets_roles ? 1 : 0
+  count       = var.create_ssm_role ? 1 : 0
   name_prefix = "jx-external-secrets-parameter-store"
   description = "external-secrets policy for cluster ${var.cluster_name} for Parameter Store ServiceAccount"
   policy      = data.aws_iam_policy_document.parameter-store-policy[count.index].json
@@ -453,9 +453,9 @@ resource "aws_iam_policy" "parameter-store" {
 module "iam_assumable_role_secrets-parameter-store" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "~> v3.8.0"
-  create_role                   = var.create_secrets_roles
+  create_role                   = var.create_ssm_role
   role_name                     = "${local.cluster_trunc}-external-secrets-parameter-store"
   provider_url                  = local.oidc_provider_url
-  role_policy_arns              = [var.create_secrets_roles ? aws_iam_policy.parameter-store[0].arn : ""]
+  role_policy_arns              = [var.create_ssm_role ? aws_iam_policy.parameter-store[0].arn : ""]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.jenkins-x-namespace}:external-secrets-parameter-store"]
 }

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -56,9 +56,14 @@ output "external_dns_iam_role" {
   description = "The IAM Role that the External DNS pod will assume to authenticate"
 }
 
-output "external_secrets_iam_role" {
-  value       = module.iam_assumable_role_external_secrets.this_iam_role_name
-  description = "The IAM Role that the External Secrets pod will assume to authenticate"
+output "external_secrets_iam_role-secrets-manager" {
+  value       = module.iam_assumable_role_secrets-secrets-manager.this_iam_role_name
+  description = "The IAM Role that the External Secrets pod will assume to authenticate (Secrets Manager)"
+}
+
+output "external_secrets_iam_role-parameter-store" {
+  value       = module.iam_assumable_role_secrets-parameter-store.this_iam_role_name
+  description = "The IAM Role that the External Secrets pod will assume to authenticate (Parameter Store)"
 }
 
 output "cm_cainjector_iam_role" {

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -56,6 +56,11 @@ output "external_dns_iam_role" {
   description = "The IAM Role that the External DNS pod will assume to authenticate"
 }
 
+output "external_secrets_iam_role" {
+  value       = module.iam_assumable_role_external_secrets.this_iam_role_name
+  description = "The IAM Role that the External Secrets pod will assume to authenticate"
+}
+
 output "cm_cainjector_iam_role" {
   value       = module.iam_assumable_role_cm_cainjector.this_iam_role_name
   description = "The IAM Role that the CM CA Injector pod will assume to authenticate"

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -56,12 +56,12 @@ output "external_dns_iam_role" {
   description = "The IAM Role that the External DNS pod will assume to authenticate"
 }
 
-output "external_secrets_iam_role-secrets-manager" {
+output "cluster_asm_iam_role" {
   value       = module.iam_assumable_role_secrets-secrets-manager.this_iam_role_name
   description = "The IAM Role that the External Secrets pod will assume to authenticate (Secrets Manager)"
 }
 
-output "external_secrets_iam_role-parameter-store" {
+output "cluster_ssm_iam_role" {
   value       = module.iam_assumable_role_secrets-parameter-store.this_iam_role_name
   description = "The IAM Role that the External Secrets pod will assume to authenticate (Parameter Store)"
 }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -354,8 +354,14 @@ variable "create_autoscaler_role" {
   default     = true
 }
 
-variable "create_secrets_roles" {
-  description = "Flag to control cluster secrets iam role creation"
+variable "create_ssm_role" {
+  description = "Flag to control AWS Parameter Store iam roles creation"
+  type        = bool
+  default     = false
+}
+
+variable "create_asm_role" {
+  description = "Flag to control AWS Secrets Manager iam roles creation"
   type        = bool
   default     = false
 }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -354,6 +354,12 @@ variable "create_autoscaler_role" {
   default     = true
 }
 
+variable "create_secrets_role" {
+  description = "Flag to control cluster secrets iam role creation"
+  type        = bool
+  default     = true
+}
+
 variable "create_pipeline_vis_role" {
   description = "Flag to control pipeline visualizer role"
   type        = bool

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -354,10 +354,10 @@ variable "create_autoscaler_role" {
   default     = true
 }
 
-variable "create_secrets_role" {
+variable "create_secrets_roles" {
   description = "Flag to control cluster secrets iam role creation"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "create_pipeline_vis_role" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -81,6 +81,16 @@ output "pipeline_viz_iam_role" {
   description = "The IAM Role that the pipeline visualizer pod will assume to authenticate"
 }
 
+output "cluster_asm_iam_role" {
+  value       = module.cluster.cluster_asm_iam_role
+  description = "The IAM Role that the External Secrets pod will assume to authenticate (Secrets Manager)"
+}
+
+output "cluster_ssm_iam_role" {
+  value       = module.cluster.cluster_ssm_iam_role
+  description = "The IAM Role that the External Secrets pod will assume to authenticate (Parameter Store)"
+}
+
 // ----------------------------------------------------------------------------
 // Vault Resources
 // ----------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -503,6 +503,12 @@ variable "create_autoscaler_role" {
   default     = true
 }
 
+variable "create_secrets_role" {
+  description = "Flag to control cluster secrets iam role creation"
+  type        = bool
+  default     = true
+}
+
 variable "create_velero_role" {
   description = "Flag to control velero iam role creation"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -503,10 +503,10 @@ variable "create_autoscaler_role" {
   default     = true
 }
 
-variable "create_secrets_role" {
-  description = "Flag to control cluster secrets iam role creation"
+variable "create_secrets_roles" {
+  description = "Flag to control cluster secrets iam roles creation"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "create_velero_role" {

--- a/variables.tf
+++ b/variables.tf
@@ -503,8 +503,14 @@ variable "create_autoscaler_role" {
   default     = true
 }
 
-variable "create_secrets_roles" {
-  description = "Flag to control cluster secrets iam roles creation"
+variable "create_ssm_role" {
+  description = "Flag to control AWS Parameter Store iam roles creation"
+  type        = bool
+  default     = false
+}
+
+variable "create_asm_role" {
+  description = "Flag to control AWS Secrets Manager iam roles creation"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description
This commit will create a ServiceAccount to access SSM and Secrets
Manager.

The resources this ServiceAccount has access to are for the ones JX
defines in it's secretMapping


#### Special notes for the reviewer(s)
Allows all Read/Write Secrets in both SSM Parameter Store and Secrets Manager for the resources defined in the secretMappings added in [this PR](https://github.com/jenkins-x/jx3-versions/pull/2544)

#### Which issue this PR fixes

