### PR TITLE
fix: added region to vault

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,6 +104,7 @@ module "vault" {
   force_destroy  = var.force_destroy
   external_vault = local.external_vault
   use_vault      = var.use_vault
+  region         = var.region
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
vault defaults to us-east-1, instead of the region used by the rest of the stack

<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #
