### PR TITLE
Allow leaving out default values and adding more fields to node groups

### DIFF
--- a/modules/cluster/local.tf
+++ b/modules/cluster/local.tf
@@ -14,6 +14,13 @@ locals {
   cert-manager-namespace = "cert-manager"
 
   node_group_defaults = {
+    ami_type         = var.node_group_ami
+    disk_size        = var.node_group_disk_size
+    desired_capacity = var.desired_node_count
+    max_capacity     = var.max_node_count
+    min_capacity     = var.min_node_count
+    instance_types   = [var.node_machine_type]
+
     launch_template_id      = null
     launch_template_version = null
 
@@ -31,27 +38,15 @@ locals {
     }
   }
 
-  node_groups_extended = length(var.node_groups) > 0 ? { for k, v in var.node_groups : k => merge(
+  node_groups_extended = { for k, v in var.node_groups : k => merge(
     local.node_group_defaults,
     v,
-    {
+    contains(keys(v), "k8s_labels") ? {
       # Deep merge isn't a thing in terraform, yet, so we commit these atrocities.
       k8s_labels = merge(
         local.node_group_defaults["k8s_labels"],
         v["k8s_labels"],
-      )
-    },
-    ) } : {
-    eks-jx-node-group = merge(
-      {
-        ami_type         = var.node_group_ami
-        disk_size        = var.node_group_disk_size
-        desired_capacity = var.desired_node_count
-        max_capacity     = var.max_node_count
-        min_capacity     = var.min_node_count
-        instance_types   = [var.node_machine_type]
-      },
-      local.node_group_defaults
-    )
-  }
+        )
+    } : {},
+    )}
 }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -73,17 +73,7 @@ variable "spot_price" {
 
 variable "node_groups" {
   description = "List of node groups to be created"
-  type = map(object({
-    ami_type                = string
-    disk_size               = number
-    desired_capacity        = number
-    max_capacity            = number
-    min_capacity            = number
-    instance_types          = list(string)
-    launch_template_id      = string
-    launch_template_version = string
-    k8s_labels              = map(string)
-  }))
+  type = any
   default = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -113,18 +113,8 @@ variable "node_group_disk_size" {
 
 variable "node_groups_managed" {
   description = "List of managed node groups to be created and their respective settings"
-  type = map(object({
-    ami_type                = string
-    disk_size               = number
-    desired_capacity        = number
-    max_capacity            = number
-    min_capacity            = number
-    instance_types          = list(string)
-    launch_template_id      = string
-    launch_template_version = string
-    k8s_labels              = map(string)
-  }))
-  default = {}
+  type = any
+  default = {eks-jx-node-group = {}}
 }
 
 variable "key_name" {


### PR DESCRIPTION


<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description
Allow leaving out default values and adding more fields to node groups. 

After #252 was applied you could specify attributes for node groups, but the way it was implemented you had to specify all fields even if you where content with the defaults and you also could not add more attributes (in my case subnets and name).

This PR fixes that.

