### PR TITLE
fix: Allow applying terraform with non root IAM user

### DIFF
--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -110,6 +110,7 @@ resource "aws_kms_key" "kms_vault_unseal" {
             "Principal": {
                 "AWS": [
                     "${length(data.aws_iam_user.vault_user) > 0 ? data.aws_iam_user.vault_user[0].arn : ""}",
+                    "${data.aws_caller_identity.current.arn}",
                     "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
                 ]
             },


### PR DESCRIPTION

<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description

Without this fix creation of aws_kms_key fails with:
MalformedPolicyDocumentException: The new key policy will not allow you to update the key policy in the future.

