### PR TITLE
fix: Get rid of interpolation warning

### DIFF
--- a/modules/nginx/main.tf
+++ b/modules/nginx/main.tf
@@ -7,6 +7,6 @@ resource "helm_release" "nginx-ingress" {
   version          = var.nginx_chart_version
   create_namespace = var.create_nginx_namespace
   values = [
-    fileexists("${path.cwd}/${var.nginx_values_file}") ? "${file("${path.cwd}/${var.nginx_values_file}")}" : "${file("${path.module}/${var.nginx_values_file}")}"
+    fileexists("${path.cwd}/${var.nginx_values_file}") ? file("${path.cwd}/${var.nginx_values_file}") : file("${path.module}/${var.nginx_values_file}")
   ]
 }


### PR DESCRIPTION
<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description

This is a fix to get rid of the warning:

```
Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/eks-jx/modules/nginx/main.tf line 10, in resource "helm_release" "nginx-ingress":
  10:     fileexists("${path.cwd}/${var.nginx_values_file}") ? "${file("${path.cwd}/${var.nginx_values_file}")}" : "${file("${path.module}/${var.nginx_values_file}")}"

```

