### PR TITLE
fix: Prevent HostedZoneNotEmpty during terraform destroy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -129,6 +129,7 @@ module "dns" {
   tls_email                      = var.tls_email
   enable_external_dns            = var.enable_external_dns
   create_and_configure_subdomain = var.create_and_configure_subdomain
+  force_destroy_subdomain        = var.force_destroy_subdomain
   enable_tls                     = var.enable_tls
   production_letsencrypt         = var.production_letsencrypt
   manage_apex_domain             = var.manage_apex_domain

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -12,6 +12,7 @@ data "aws_route53_zone" "apex_domain_zone" {
 resource "aws_route53_zone" "subdomain_zone" {
   count = var.create_and_configure_subdomain && var.manage_subdomain ? 1 : 0
   name  = join(".", [var.subdomain, var.apex_domain])
+  force_destroy = var.force_destroy_subdomain
 }
 
 resource "aws_route53_record" "subdomain_ns_delegation" {

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -29,6 +29,12 @@ variable "create_and_configure_subdomain" {
   default = false
 }
 
+variable "force_destroy_subdomain" {
+  description = "Flag to determine whether subdomain zone get forcefully destroyed. If set to false, empty the sub domain first in the aws Route 53 console, else terraform destroy will fail with HostedZoneNotEmpty error"
+  type        = bool
+  default     = false
+}
+
 variable "enable_tls" {
   type    = bool
   default = false

--- a/variables.tf
+++ b/variables.tf
@@ -243,6 +243,12 @@ variable "create_and_configure_subdomain" {
   default     = false
 }
 
+variable "force_destroy_subdomain" {
+  description = "Flag to determine whether subdomain zone get forcefully destroyed. If set to false, empty the sub domain first in the aws Route 53 console, else terraform destroy will fail with HostedZoneNotEmpty error"
+  type        = bool
+  default     = false
+}
+
 variable "enable_tls" {
   description = "Flag to enable TLS in the final `jx-requirements.yml` file"
   type        = bool


### PR DESCRIPTION
<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description

When doing terraform destroy and you have set create_and_configure_subdomain then it will fail with HostedZoneNotEmpty if there are entries in the zone (typically created by external-dns). This fix gives to option to have the zone destroyed anyway.

