### PR TITLE
fix: create one launch template instead of per subnet

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -69,9 +69,8 @@ module "eks" {
   enable_irsa     = true
 
   worker_groups_launch_template = var.enable_worker_group && var.enable_worker_groups_launch_template ? [
-    for subnet in(var.create_vpc ? module.vpc.public_subnets : var.subnets) :
     {
-      subnets                 = [subnet]
+      subnets                 = [var.create_vpc ? module.vpc.public_subnets : var.subnets]
       asg_desired_capacity    = var.lt_desired_nodes_per_subnet
       asg_min_size            = var.lt_min_nodes_per_subnet
       asg_max_size            = var.lt_max_nodes_per_subnet


### PR DESCRIPTION

<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description
having a separate launch template for worker nodes is not useful.
instead create one, and the asg will also be for all the subnets

