### PR TITLE
feat: tag subnets manually if not creating vpc

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -55,6 +55,31 @@ module "vpc" {
 }
 
 // ----------------------------------------------------------------------------
+// Manually Tag VPC Subnets if needed
+// See https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html#vpc-subnet-tagging
+// ----------------------------------------------------------------------------
+resource "aws_ec2_tag" "public_subnet_tag" {
+  for_each    = var.create_vpc ? [] : var.cluster_in_private_subnet ? [] : toset(var.subnets)
+  resource_id = each.value
+  key         = "kubernetes.io/role/elb"
+  value       = "1"
+}
+
+resource "aws_ec2_tag" "private_subnet_tag" {
+  for_each    = var.create_vpc ? [] : var.cluster_in_private_subnet ? toset(var.subnets) : []
+  resource_id = each.value
+  key         = "kubernetes.io/role/internal-elb"
+  value       = "1"
+}
+
+resource "aws_ec2_tag" "subnet_cluster_tag" {
+  for_each    = var.create_vpc ? [] : toset(var.subnets)
+  resource_id = each.value
+  key         = "kubernetes.io/cluster/${var.cluster_name}"
+  value       = "shared"
+}
+
+// ----------------------------------------------------------------------------
 // Create the EKS cluster with extra EC2ContainerRegistryPowerUser policy
 // See https://github.com/terraform-aws-modules/terraform-aws-eks
 // ----------------------------------------------------------------------------


### PR DESCRIPTION

<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description
a cluster with version 1.19+ no longer creates subnet tags
automatically.

And also when not creating a VPC, we still need to tag
the subnets as public or private

This commit adds the relavant tags.

Source: https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html#vpc-subnet-tagging
and also https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html