### PR TITLE
fix: use external-secret standard naming

### DIFF
--- a/modules/cluster/irsa.tf
+++ b/modules/cluster/irsa.tf
@@ -421,7 +421,7 @@ module "iam_assumable_role_secrets-secrets-manager" {
 // ----------------------------------------------------------------------------
 // External Secrets - Parameter Store
 // ----------------------------------------------------------------------------
-data "aws_iam_policy_document" "parameter-store-policy" {
+data "aws_iam_policy_document" "system-manager-policy" {
   count = var.create_ssm_role ? 1 : 0
   statement {
     effect = "Allow"
@@ -443,19 +443,19 @@ data "aws_iam_policy_document" "parameter-store-policy" {
   }
 }
 
-resource "aws_iam_policy" "parameter-store" {
+resource "aws_iam_policy" "system-manager" {
   count       = var.create_ssm_role ? 1 : 0
-  name_prefix = "jx-external-secrets-parameter-store"
+  name_prefix = "jx-external-secrets-system-manager"
   description = "external-secrets policy for cluster ${var.cluster_name} for Parameter Store ServiceAccount"
-  policy      = data.aws_iam_policy_document.parameter-store-policy[count.index].json
+  policy      = data.aws_iam_policy_document.system-manager-policy[count.index].json
 }
 
-module "iam_assumable_role_secrets-parameter-store" {
+module "iam_assumable_role_secrets-system-manager" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "~> v3.8.0"
   create_role                   = var.create_ssm_role
-  role_name                     = "${local.cluster_trunc}-external-secrets-parameter-store"
+  role_name                     = "${local.cluster_trunc}-external-secrets-system-manager"
   provider_url                  = local.oidc_provider_url
-  role_policy_arns              = [var.create_ssm_role ? aws_iam_policy.parameter-store[0].arn : ""]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.jenkins-x-namespace}:external-secrets-parameter-store"]
+  role_policy_arns              = [var.create_ssm_role ? aws_iam_policy.system-manager[0].arn : ""]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.jenkins-x-namespace}:external-secrets-system-manager"]
 }

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -71,7 +71,7 @@ output "cluster_asm_iam_role" {
 }
 
 output "cluster_ssm_iam_role" {
-  value       = module.iam_assumable_role_secrets-parameter-store.this_iam_role_name
+  value       = module.iam_assumable_role_secrets-system-manager.this_iam_role_name
   description = "The IAM Role that the External Secrets pod will assume to authenticate (Parameter Store)"
 }
 


### PR DESCRIPTION

<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description
renamed parameter-store to secret-manager as ExternalSecrets uses that
convention.


#### Special notes for the reviewer(s)
related: https://github.com/jenkins-x/jx3-versions/pull/2619

