### PR TITLE
refactor: change constraints for eks module to support eks 1.21

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -60,7 +60,7 @@ module "vpc" {
 // ----------------------------------------------------------------------------
 module "eks" {
   source          = "terraform-aws-modules/eks/aws"
-  version         = ">= 14.0, < 16.0"
+  version         = ">= 14.0, < 18.0"
   create_eks      = var.create_eks
   cluster_name    = var.cluster_name
   cluster_version = var.cluster_version


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

#### Description
For eks 1.21, we need eks module to be bumped to 1.17+, but we have a constrant < 16.0, so this PR fixes that.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #
