### PR TITLE
fix: change secrets manager name in requirements file

### DIFF
--- a/modules/cluster/irsa.tf
+++ b/modules/cluster/irsa.tf
@@ -397,9 +397,9 @@ data "aws_iam_policy_document" "secrets-manager-policy" {
       "secretsmanager:UpdateSecret",
     ]
     resources = [
-
-      "*",
-
+      "arn:${data.aws_partition.current.partition}:secretsmanager:${var.region}:${local.project}:secret:secret/data/lighthouse/*",
+      "arn:${data.aws_partition.current.partition}:secretsmanager:${var.region}:${local.project}:secret:secret/data/jx/*",
+      "arn:${data.aws_partition.current.partition}:secretsmanager:${var.region}:${local.project}:secret:secret/data/nexus/*"
     ]
   }
 }

--- a/modules/cluster/irsa.tf
+++ b/modules/cluster/irsa.tf
@@ -398,7 +398,7 @@ data "aws_iam_policy_document" "secrets-manager-policy" {
     ]
     resources = [
 
-      "arn:${data.aws_partition.current.partition}:secretsmanager:${var.region}:${local.project}:secret:secret/data/*",
+      "*",
 
     ]
   }

--- a/modules/cluster/irsa.tf
+++ b/modules/cluster/irsa.tf
@@ -397,9 +397,9 @@ data "aws_iam_policy_document" "secrets-manager-policy" {
       "secretsmanager:UpdateSecret",
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:secretsmanager:${var.region}:${local.project}:secret:secret/data/lighthouse/*",
-      "arn:${data.aws_partition.current.partition}:secretsmanager:${var.region}:${local.project}:secret:secret/data/jx/*",
-      "arn:${data.aws_partition.current.partition}:secretsmanager:${var.region}:${local.project}:secret:secret/data/nexus/*"
+
+      "arn:${data.aws_partition.current.partition}:secretsmanager:${var.region}:${local.project}:secret:secret/data/*",
+
     ]
   }
 }

--- a/templates/jx-requirements.yml.tpl
+++ b/templates/jx-requirements.yml.tpl
@@ -37,7 +37,7 @@ vault:
 %{ endif }
 %{ endif }
 %{ if use_asm }
-secretStorage: asm
+secretStorage: secretsManager
 %{ endif }
 %{ if enable_backup }
 velero:


### PR DESCRIPTION
Terraform sets the name of the secretStorage to "asm", which is not recognised in the gitops operator, who expects the name "secretsManager". The current setup makes the default configuration the only configuration you ever can get. Which makes it really hard to change things.