### PR TITLE
fix: External secrets from vault

### DIFF
--- a/modules/vault/charts.tf
+++ b/modules/vault/charts.tf
@@ -14,6 +14,6 @@ resource "helm_release" "vault-instance" {
   chart      = "vault-instance"
   namespace  = "jx-vault"
   repository = "https://jenkins-x-charts.github.io/repo"
-  version    = "1.0.20"
+  version    = "1.0.21"
   depends_on = [helm_release.vault-operator]
 }


### PR DESCRIPTION
This should fix that secrets failed to be populated from vault by kubernetes-external-secrets. The log of kubernetes-external-secrets showed errors like:
{"level":50,"time":1630943166224,"pid":17,"hostname":"kubernetes-external-secrets-7686994b8c-ldrwh","payload":{"response":{"statusCode":400,"body":{"errors":["invalid role name \"jx-vault\""]}}},"msg":"failure while polling the secret jx/lighthouse-hmac-token"}

<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #
