### PR TITLE
fix: change external secrets namespace to secret-infra

### DIFF
--- a/examples/customers_certificate/main.tf
+++ b/examples/customers_certificate/main.tf
@@ -1,5 +1,5 @@
 module "eks-jx" {
-  source     = "jenkins-x/eks-jx/aws"
+  source = "jenkins-x/eks-jx/aws"
 
   enable_external_dns = true
   apex_domain         = "office.com"
@@ -8,6 +8,6 @@ module "eks-jx" {
   tls_email           = "customer@office.com"
 
   // Signed Certificate must match the domain: *.subdomain.office.com
-  tls_cert            = var.tls_cert
-  tls_key             = var.tls_key
+  tls_cert = var.tls_cert
+  tls_key  = var.tls_key
 }

--- a/modules/cluster/irsa.tf
+++ b/modules/cluster/irsa.tf
@@ -416,7 +416,7 @@ module "iam_assumable_role_secrets-secrets-manager" {
   role_name                     = "${local.cluster_trunc}-external-secrets-secrets-manager"
   provider_url                  = local.oidc_provider_url
   role_policy_arns              = [var.create_asm_role ? aws_iam_policy.secrets-manager[0].arn : ""]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.jenkins-x-namespace}:external-secrets-secrets-manager"]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.secret-infra-namespace}:kubernetes-external-secrets"]
 }
 // ----------------------------------------------------------------------------
 // External Secrets - Parameter Store
@@ -457,5 +457,5 @@ module "iam_assumable_role_secrets-system-manager" {
   role_name                     = "${local.cluster_trunc}-external-secrets-system-manager"
   provider_url                  = local.oidc_provider_url
   role_policy_arns              = [var.create_ssm_role ? aws_iam_policy.system-manager[0].arn : ""]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.jenkins-x-namespace}:external-secrets-system-manager"]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.secret-infra-namespace}:kubernetes-external-secrets"]
 }

--- a/modules/cluster/local.tf
+++ b/modules/cluster/local.tf
@@ -12,6 +12,7 @@ locals {
   jenkins-x-namespace    = "jx"
   cluster_trunc          = substr(var.cluster_name, 0, 35)
   cert-manager-namespace = "cert-manager"
+  secret-infra-namespace = "secret-infra"
   project                = data.aws_caller_identity.current.account_id
 
   node_group_defaults = {

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -10,8 +10,8 @@ data "aws_route53_zone" "apex_domain_zone" {
 }
 
 resource "aws_route53_zone" "subdomain_zone" {
-  count = var.create_and_configure_subdomain && var.manage_subdomain ? 1 : 0
-  name  = join(".", [var.subdomain, var.apex_domain])
+  count         = var.create_and_configure_subdomain && var.manage_subdomain ? 1 : 0
+  name          = join(".", [var.subdomain, var.apex_domain])
   force_destroy = var.force_destroy_subdomain
 }
 


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description
External secrets does not work with IRSA because the pod cannot assume the iam role attached to the service account.
The reason is that in the  the assume role policy document the namespace of the external secrets service account is set to jx namespace, but the it's in secret-infra account

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #293 
