### PR TITLE
fix: lifecycle ignore prevents users from chart version updates

### DIFF
--- a/modules/cluster/charts.tf
+++ b/modules/cluster/charts.tf
@@ -28,9 +28,6 @@ resource "helm_release" "jx-git-operator" {
     value = var.jx_bot_token
   }
 
-  lifecycle {
-    ignore_changes = all
-  }
   depends_on = [
     null_resource.kubeconfig
   ]


### PR DESCRIPTION
this leads to additional breakages, as the older chart version may point to a docker image that no longer exists: https://kubernetes.slack.com/archives/C9LTHT2BB/p1631639873074600

Signed-off-by: Patrick Lee Scott <pat@patscott.io>

<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description


#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #
