### PR TITLE
Fix #288: not able to use AWS Profiles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,7 @@ We use GitHub issues to track public bugs. Report a bug by opening a new issue h
 ## Run make test to test your infrastructure after running Terraform
 
 ```shell
+$ make lint      # runs the linter
 $ make test      # runs terratest tests against your currently connected AWS account.
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -96,6 +96,7 @@ module "cluster" {
   tls_cert                              = var.tls_cert
   tls_key                               = var.tls_key
   local-exec-interpreter                = var.local-exec-interpreter
+  profile                               = var.profile
 }
 
 // ----------------------------------------------------------------------------

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -148,7 +148,7 @@ resource "null_resource" "kubeconfig" {
     module.eks
   ]
   provisioner "local-exec" {
-    command     = "aws eks update-kubeconfig --name ${var.cluster_name} --region=${var.region}"
+    command     = "aws eks update-kubeconfig --name ${var.cluster_name} --region=${var.region} ${var.profile ? --profile=var.profile : ""}"
     interpreter = var.local-exec-interpreter
   }
 }

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -148,7 +148,7 @@ resource "null_resource" "kubeconfig" {
     module.eks
   ]
   provisioner "local-exec" {
-    command     = "aws eks update-kubeconfig --name ${var.cluster_name} --region=${var.region} ${var.profile ? --profile=var.profile : ""}"
+    command     = "aws eks update-kubeconfig --name ${var.cluster_name} --region=${var.region} --profile=${var.profile}"
     interpreter = var.local-exec-interpreter
   }
 }

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -148,7 +148,7 @@ resource "null_resource" "kubeconfig" {
     module.eks
   ]
   provisioner "local-exec" {
-    command     = "aws eks update-kubeconfig --name ${var.cluster_name} --region=${var.region} --profile=${var.profile}"
+    command     = "aws eks update-kubeconfig --name ${var.cluster_name} --region=${var.region} ${var.profile == null ? "" : format("--profile=%s", var.profile)}"
     interpreter = var.local-exec-interpreter
   }
 }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -13,6 +13,12 @@ variable "cluster_version" {
   type        = string
 }
 
+variable "profile" {
+  description = "The AWS Profile used to provision the EKS Cluster"
+  type        = string
+  default     = null
+}
+
 # Worker Nodes
 variable "desired_node_count" {
   type    = number

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "cluster_name" {
   default     = ""
 }
 
+variable "profile" {
+  description = "The AWS Profile used to provition the EKS Cluster"
+  type        = string
+  default     = "default"
+}
+
 variable "cluster_version" {
   description = "Kubernetes version to use for the EKS cluster."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,6 @@ variable "cluster_name" {
 variable "profile" {
   description = "The AWS Profile used to provision the EKS Cluster"
   type        = string
-  default     = "default"
 }
 
 variable "cluster_version" {

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "cluster_name" {
 }
 
 variable "profile" {
-  description = "The AWS Profile used to provition the EKS Cluster"
+  description = "The AWS Profile used to provision the EKS Cluster"
   type        = string
   default     = "default"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,7 @@ variable "cluster_name" {
 variable "profile" {
   description = "The AWS Profile used to provision the EKS Cluster"
   type        = string
+  default     = null
 }
 
 variable "cluster_version" {


### PR DESCRIPTION
<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
-->
#### Description
Many companies use the AWS best practice of requiring users to assume into a role that grants access to a given account representing an environment (dev, stage, prod etc). When I tried to spin up a cluster using the [jx3-terraform-eks](https://github.com/jx3-gitops-repositories/jx3-terraform-eks) repo, it failed because in this module, there is a direct call to AWS that doesn't honor the profile I set in the  [jx3-terraform-eks](https://github.com/jx3-gitops-repositories/jx3-terraform-eks) terraform variables. This PR adds a conditional flag on the only direct AWS call I could find. Please point out if there are more.

#### Special notes for the reviewer(s)
In theory this should be backwards compatible because if the variable isn't set the flag wouldn't be added. If this is pulled in I will need to make a separate PR in [jx3-terraform-eks](https://github.com/jx3-gitops-repositories/jx3-terraform-eks) for forwarding the profile to this modules, but first things first.

#### Which issue this PR fixes

fixes #288 
