### PR TITLE
feat: add option to change volume type and size for launch templates

### DIFF
--- a/examples/jx3/main.tf
+++ b/examples/jx3/main.tf
@@ -5,11 +5,15 @@ provider "aws" {
 
 
 module "eks-jx" {
-  source               = "../../"
-  vault_user           = var.vault_user
-  is_jx2               = false
-  install_kuberhealthy = true
-  create_nginx         = true
-  cluster_version      = "1.21"
-  nginx_chart_version  = "3.12.0"
+  source                               = "../../"
+  vault_user                           = var.vault_user
+  is_jx2                               = false
+  install_kuberhealthy                 = true
+  create_nginx                         = true
+  cluster_version                      = "1.21"
+  nginx_chart_version                  = "3.12.0"
+  enable_worker_groups_launch_template = true
+  volume_type                          = "gp3"
+  volume_size                          = "100"
+  encrypt_volume_self                  = true
 }

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -77,6 +77,8 @@ module "eks" {
       asg_max_size            = var.lt_max_nodes_per_subnet
       spot_price              = (var.enable_spot_instances ? var.spot_price : null)
       instance_type           = var.node_machine_type
+      root_volume_type        = var.volume_type
+      root_volume_size        = var.volume_size
       root_encrypted          = var.encrypt_volume_self
       override_instance_types = var.allowed_spot_instance_types
       autoscaling_enabled     = "true"

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -271,7 +271,7 @@ variable "lt_max_nodes_per_subnet" {
 
 variable "jx_git_operator_values" {
   description = "Extra values for jx-git-operator chart as a list of yaml formated strings"
-  type        = list(string)    
+  type        = list(string)
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -408,7 +408,7 @@ variable "registry" {
 
 variable "jx_git_operator_values" {
   description = "Extra values for jx-git-operator chart as a list of yaml formated strings"
-  type        = list(string)    
+  type        = list(string)
   default     = []
 }
 


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>


#### Description
This PR adds an option to modify volume type and size in launch templates. 
While we are adding this functionality, my advice would be to use the much more powerful aws eks module and vpc module to create the vpc and eks (we use those internally anyways for the eks-jx module), and then use the eks-jx module to create only the jx specific parts by setting `create_eks = false` and `create_vpc = false`

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #
