### PR TITLE
feat: add variable to set boot secrets

### DIFF
--- a/examples/jx3/main.tf
+++ b/examples/jx3/main.tf
@@ -16,4 +16,16 @@ module "eks-jx" {
   volume_type                          = "gp3"
   volume_size                          = "100"
   encrypt_volume_self                  = true
+  boot_secrets = [
+    {
+      name  = "jxBootJobEnvVarSecrets.EXTERNAL_VAULT"
+      value = "true"
+      type  = "string"
+    },
+    {
+      name  = "jxBootJobEnvVarSecrets.VAULT_ADDR"
+      value = "http://ankitm123-ms-7c02:8200"
+      type  = "string"
+    }
+  ]
 }

--- a/main.tf
+++ b/main.tf
@@ -101,6 +101,7 @@ module "cluster" {
   enable_logs_storage                   = var.enable_logs_storage
   enable_reports_storage                = var.enable_reports_storage
   enable_repository_storage             = var.enable_repository_storage
+  boot_secrets                          = var.boot_secrets
 }
 
 // ----------------------------------------------------------------------------

--- a/modules/cluster/charts.tf
+++ b/modules/cluster/charts.tf
@@ -30,6 +30,15 @@ resource "helm_release" "jx-git-operator" {
     value = var.jx_bot_token
   }
 
+  dynamic "set" {
+    for_each = toset(var.boot_secrets)
+    content {
+      name  = set.value["name"]
+      value = set.value["value"]
+      type  = set.value["type"]
+    }
+  }
+
   depends_on = [
     null_resource.kubeconfig
   ]

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -418,3 +418,14 @@ variable "tls_cert" {
   type        = string
   default     = ""
 }
+
+
+variable "boot_secrets" {
+  description = ""
+  type = list(object({
+    name  = string
+    value = string
+    type  = string
+  }))
+  default = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -626,3 +626,13 @@ variable "nginx_values_file" {
   type        = string
   description = "Name of the values file which holds the helm chart values"
 }
+
+variable "boot_secrets" {
+  description = ""
+  type = list(object({
+    name  = string
+    value = string
+    type  = string
+  }))
+  default = []
+}


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

#### Description
This PR adds a `boot_secret` variable which can set some env variables during the boot process to make working with external vault more convenient.

#### Special notes for the reviewer(s)


#### Which issue this PR fixes

fixes #324 
