### PR TITLE
fix: pass custom asm_role to the cluster submodule

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,14 +4,15 @@ Add this section after we add tests and compliance
 
 - [ ] Change is code complete and matches issue description.
 - [ ] Change is covered by existing or new tests.
-- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated 
+- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated
 -->
+
 #### Description
 
-
 #### Special notes for the reviewer(s)
-
 
 #### Which issue this PR fixes
 
 fixes #
+
+#### Release notes

--- a/main.tf
+++ b/main.tf
@@ -103,6 +103,7 @@ module "cluster" {
   enable_repository_storage             = var.enable_repository_storage
   boot_secrets                          = var.boot_secrets
   use_asm                               = var.use_asm
+  asm_role                              = var.asm_role
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

#### Release notes

Fixes a bug where custom ASM role was always set as blank even if the user set the correct value in asm_role variable.
