### PR TITLE
fix: Check existence of correct bucket for bucketrepo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
 - rawlingsj
 - jstrachan
 - MarckK
+- msvticket
 reviewers:
 - cagiti
 - daveconde
@@ -18,3 +19,4 @@ reviewers:
 - rawlingsj
 - jstrachan
 - MarckK
+- msvticket

--- a/modules/cluster/irsa.tf
+++ b/modules/cluster/irsa.tf
@@ -351,7 +351,7 @@ module "iam_assumable_role_pipeline_visualizer" {
 
 // Bucketrepo
 data "aws_iam_policy_document" "bucketrepo-policy" {
-  count = var.create_bucketrepo_role && length(aws_s3_bucket.logs_jenkins_x) > 0 ? 1 : 0
+  count = var.create_bucketrepo_role && length(aws_s3_bucket.repository_jenkins_x) > 0 ? 1 : 0
   statement {
     sid    = "BucketRepoPolicy"
     effect = "Allow"
@@ -363,7 +363,7 @@ data "aws_iam_policy_document" "bucketrepo-policy" {
 }
 
 resource "aws_iam_policy" "bucketrepo" {
-  count       = var.create_bucketrepo_role && length(aws_s3_bucket.logs_jenkins_x) > 0 ? 1 : 0
+  count       = var.create_bucketrepo_role && length(aws_s3_bucket.repository_jenkins_x) > 0 ? 1 : 0
   name_prefix = "jx-bucketrepo"
   description = "bucketrepo policy for cluster ${var.cluster_name}"
   policy      = data.aws_iam_policy_document.bucketrepo-policy[count.index].json
@@ -372,10 +372,10 @@ resource "aws_iam_policy" "bucketrepo" {
 module "iam_assumable_role_bucketrepo" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "~> v3.8.0"
-  create_role                   = var.create_bucketrepo_role && length(aws_s3_bucket.logs_jenkins_x) > 0
+  create_role                   = var.create_bucketrepo_role && length(aws_s3_bucket.repository_jenkins_x) > 0
   role_name                     = "${local.cluster_trunc}-jx-bucketrepo"
   provider_url                  = local.oidc_provider_url
-  role_policy_arns              = [var.create_bucketrepo_role && length(aws_s3_bucket.logs_jenkins_x) > 0 ? aws_iam_policy.bucketrepo[0].arn : ""]
+  role_policy_arns              = [var.create_bucketrepo_role && length(aws_s3_bucket.repository_jenkins_x) > 0 ? aws_iam_policy.bucketrepo[0].arn : ""]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.jenkins-x-namespace}:bucketrepo-bucketrepo"]
 }
 


### PR DESCRIPTION
#### Description

When giving the variable `enable_repository_storage = false` to the module I got this error:

```
│ Error: Invalid index
│
│   on .terraform/modules/eks-jx/modules/cluster/irsa.tf line 361, in data "aws_iam_policy_document" "bucketrepo-policy":
│  361:     resources = [aws_s3_bucket.repository_jenkins_x.*.arn[0], "${aws_s3_bucket.repository_jenkins_x.*.arn[0]}/*"]
│     ├────────────────
│     │ aws_s3_bucket.repository_jenkins_x is empty tuple
│
│ The given key does not identify an element in this collection value: the
│ collection has no elements.
╵
╷
│ Error: Invalid index
│
│   on .terraform/modules/eks-jx/modules/cluster/irsa.tf line 361, in data "aws_iam_policy_document" "bucketrepo-policy":
│  361:     resources = [aws_s3_bucket.repository_jenkins_x.*.arn[0], "${aws_s3_bucket.repository_jenkins_x.*.arn[0]}/*"]
│     ├────────────────
│     │ aws_s3_bucket.repository_jenkins_x is empty tuple
│
│ The given key does not identify an element in this collection value: the
│ collection has no elements.
```

The work around now is to explicitly also give `create_bucketrepo_role = false`. With this PR that work around should be not be needed.