### PR TITLE
Adding capability to configure private Route53 domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,8 +667,8 @@ Each example generates a valid _jx-requirements.yml_ file that can be used to bo
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.64.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.3 |
 #### Modules
 
 | Name | Source | Version |
@@ -690,7 +690,6 @@ Each example generates a valid _jx-requirements.yml_ file that can be used to bo
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | ~> 2.0 |
 #### Inputs
 
 | Name | Description | Type | Default | Required |
@@ -708,6 +707,7 @@ Each example generates a valid _jx-requirements.yml_ file that can be used to bo
 | <a name="input_cluster_in_private_subnet"></a> [cluster\_in\_private\_subnet](#input\_cluster\_in\_private\_subnet) | Flag to enable installation of cluster on private subnets | `bool` | `false` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Variable to provide your desired name for the cluster. The script will create a random name if this is empty | `string` | `""` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Kubernetes version to use for the EKS cluster. | `string` | n/a | yes |
+| <a name="input_create_and_configure_private_subdomain"></a> [create\_and\_configure\_private\_subdomain](#input\_create\_and\_configure\_private\_subdomain) | Flag to create an NS record set for the private subdomain in the VPC | `bool` | `false` | no |
 | <a name="input_create_and_configure_subdomain"></a> [create\_and\_configure\_subdomain](#input\_create\_and\_configure\_subdomain) | Flag to create an NS record set for the subdomain in the apex domain's Hosted Zone | `bool` | `false` | no |
 | <a name="input_create_asm_role"></a> [create\_asm\_role](#input\_create\_asm\_role) | Flag to control AWS Secrets Manager iam roles creation | `bool` | `false` | no |
 | <a name="input_create_autoscaler_role"></a> [create\_autoscaler\_role](#input\_create\_autoscaler\_role) | Flag to control cluster autoscaler iam role creation | `bool` | `true` | no |
@@ -768,6 +768,7 @@ Each example generates a valid _jx-requirements.yml_ file that can be used to bo
 | <a name="input_node_group_disk_size"></a> [node\_group\_disk\_size](#input\_node\_group\_disk\_size) | node group worker disk size | `string` | `"50"` | no |
 | <a name="input_node_groups_managed"></a> [node\_groups\_managed](#input\_node\_groups\_managed) | List of managed node groups to be created and their respective settings | `any` | <pre>{<br>  "eks-jx-node-group": {}<br>}</pre> | no |
 | <a name="input_node_machine_type"></a> [node\_machine\_type](#input\_node\_machine\_type) | The instance type to use for the cluster's worker nodes | `string` | `"m5.large"` | no |
+| <a name="input_private_dns_associated_vpc_ids"></a> [private\_dns\_associated\_vpc\_ids](#input\_private\_dns\_associated\_vpc\_ids) | A map of other vpc ids and there region to associate with the private zone | `map(string)` | `{}` | no |
 | <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | The private subnet CIDR block to use in the created VPC | `list(string)` | <pre>[<br>  "10.0.4.0/24",<br>  "10.0.5.0/24",<br>  "10.0.6.0/24"<br>]</pre> | no |
 | <a name="input_production_letsencrypt"></a> [production\_letsencrypt](#input\_production\_letsencrypt) | Flag to use the production environment of letsencrypt in the `jx-requirements.yml` file | `bool` | `false` | no |
 | <a name="input_profile"></a> [profile](#input\_profile) | The AWS Profile used to provision the EKS Cluster | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -137,17 +137,25 @@ module "backup" {
 // Setup all required Route 53 resources if External DNS / Cert Manager is enabled
 // ----------------------------------------------------------------------------
 module "dns" {
-  source                         = "./modules/dns"
-  apex_domain                    = var.apex_domain
-  subdomain                      = var.subdomain
-  tls_email                      = var.tls_email
-  enable_external_dns            = var.enable_external_dns
-  create_and_configure_subdomain = var.create_and_configure_subdomain
-  force_destroy_subdomain        = var.force_destroy_subdomain
-  enable_tls                     = var.enable_tls
-  production_letsencrypt         = var.production_letsencrypt
-  manage_apex_domain             = var.manage_apex_domain
-  manage_subdomain               = var.manage_subdomain
+  source                  = "./modules/dns"
+  apex_domain             = var.apex_domain
+  subdomain               = var.subdomain
+  tls_email               = var.tls_email
+  enable_external_dns     = var.enable_external_dns
+  force_destroy_subdomain = var.force_destroy_subdomain
+  enable_tls              = var.enable_tls
+  production_letsencrypt  = var.production_letsencrypt
+  manage_apex_domain      = var.manage_apex_domain
+  manage_subdomain        = var.manage_subdomain
+
+
+  create_and_configure_subdomain         = var.create_and_configure_subdomain
+  create_and_configure_private_subdomain = var.create_and_configure_private_subdomain
+  private_dns_associated_vpc_ids         = var.private_dns_associated_vpc_ids
+
+  // used if creating private subdomain
+  vpc_id = var.vpc_id
+  region = var.region
 }
 
 module "health" {

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -15,6 +15,28 @@ resource "aws_route53_zone" "subdomain_zone" {
   force_destroy = var.force_destroy_subdomain
 }
 
+resource "aws_route53_zone" "private_zone" {
+
+  count = var.create_and_configure_subdomain && var.create_and_configure_private_subdomain ? 1 : 0
+  name  = join(".", [var.subdomain, var.apex_domain])
+
+  vpc {
+    vpc_id     = var.vpc_id
+    vpc_region = var.region
+  }
+
+  lifecycle {
+    ignore_changes = [vpc]
+  }
+}
+
+resource "aws_route53_zone_association" "secondary" {
+  zone_id    = aws_route53_zone.private_zone[0].zone_id
+  for_each   = tomap(var.private_dns_associated_vpc_ids)
+  vpc_id     = each.key
+  vpc_region = each.value
+}
+
 resource "aws_route53_record" "subdomain_ns_delegation" {
   count   = var.create_and_configure_subdomain && var.manage_apex_domain ? 1 : 0
   zone_id = data.aws_route53_zone.apex_domain_zone[0].zone_id

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -29,6 +29,12 @@ variable "create_and_configure_subdomain" {
   default = false
 }
 
+variable "create_and_configure_private_subdomain" {
+  description = "Flag to determine if a private subdomain is created and configured."
+  type        = bool
+  default     = false
+}
+
 variable "force_destroy_subdomain" {
   description = "Flag to determine whether subdomain zone get forcefully destroyed. If set to false, empty the sub domain first in the aws Route 53 console, else terraform destroy will fail with HostedZoneNotEmpty error"
   type        = bool
@@ -61,3 +67,25 @@ variable "manage_subdomain" {
   default     = true
   type        = bool
 }
+
+// ----------------------------------------------------------------------------
+// Variables if setting private Route53 configuration
+// ----------------------------------------------------------------------------
+variable "vpc_id" {
+  description = "The VPC to create EKS cluster in if create_vpc is false"
+  type        = string
+  default     = ""
+}
+
+variable "region" {
+  description = "The region to create the resources into"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "private_dns_associated_vpc_ids" {
+  description = "A map of other vpc ids and there region to associate with the private zone"
+  type        = map(string)
+  default     = {}
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -239,6 +239,18 @@ variable "create_and_configure_subdomain" {
   default     = false
 }
 
+variable "create_and_configure_private_subdomain" {
+  description = "Flag to create an NS record set for the private subdomain in the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "private_dns_associated_vpc_ids" {
+  description = "A map of other vpc ids and there region to associate with the private zone"
+  type        = map(string)
+  default     = {}
+}
+
 variable "force_destroy_subdomain" {
   description = "Flag to determine whether subdomain zone get forcefully destroyed. If set to false, empty the sub domain first in the aws Route 53 console, else terraform destroy will fail with HostedZoneNotEmpty error"
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,6 @@ terraform {
     kubernetes = "~> 2.0"
     local      = "~> 2.0"
     null       = "~> 3.0"
-    template   = "~> 2.0"
     random     = "~> 3.0"
     helm       = "~> 2.0"
   }


### PR DESCRIPTION
#### Description

At times a user will want to configure private Route53 domains.
This introduces the capability to set a flag and have terraform
create the private Route53 DNS entries.

This feature is useful to configure such things as split DNS and
also allow for private DNS entries for such things as nexus and
chartmuseum.

- [X] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [X] Readme is updated
- [ ] jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated

#### Notes for reviewers

I have not checked the use case where we are creating the VPC itself.  How would I get the vpc id then?

#### Which issue this PR fixes

fixes #349

#### Release notes

New flag added to allow for the create a private Route53 domain.  Set `create_and_configure_private_subdomain` to true
and this module will create and manage the private domain. 
