### PR TITLE
chore: Upgrade bank-vaults

### DIFF
--- a/modules/vault/charts.tf
+++ b/modules/vault/charts.tf
@@ -4,7 +4,7 @@ resource "helm_release" "vault-operator" {
   chart            = "vault-operator"
   namespace        = "jx-vault"
   repository       = "https://kubernetes-charts.banzaicloud.com"
-  version          = "1.14.3"
+  version          = "1.15.3"
   create_namespace = true
 }
 

--- a/modules/vault/charts.tf
+++ b/modules/vault/charts.tf
@@ -14,6 +14,6 @@ resource "helm_release" "vault-instance" {
   chart      = "vault-instance"
   namespace  = "jx-vault"
   repository = "https://jenkins-x-charts.github.io/repo"
-  version    = "1.0.24"
+  version    = "1.0.26"
   depends_on = [helm_release.vault-operator]
 }


### PR DESCRIPTION
#### Description

The main reason for the upgrade is to get a version of vault with good support for short lived service account tokens. 

https://www.vaultproject.io/docs/auth/kubernetes#kubernetes-1-21

