### PR TITLE
feat: Allow specifying boot_iam_role

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,8 +667,8 @@ Each example generates a valid _jx-requirements.yml_ file that can be used to bo
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.64.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | > 4.0, < 5.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 #### Modules
 
 | Name | Source | Version |
@@ -698,7 +698,8 @@ Each example generates a valid _jx-requirements.yml_ file that can be used to bo
 | <a name="input_additional_tekton_role_policy_arns"></a> [additional\_tekton\_role\_policy\_arns](#input\_additional\_tekton\_role\_policy\_arns) | Additional Policy ARNs to attach to Tekton IRSA Role | `list(string)` | `[]` | no |
 | <a name="input_allowed_spot_instance_types"></a> [allowed\_spot\_instance\_types](#input\_allowed\_spot\_instance\_types) | Allowed machine types for spot instances (must be same size) | `any` | `[]` | no |
 | <a name="input_apex_domain"></a> [apex\_domain](#input\_apex\_domain) | The main domain to either use directly or to configure a subdomain from | `string` | `""` | no |
-| <a name="input_asm_role"></a> [asm\_role](#input\_asm\_role) | Specify arn of the ASM role (custom not created by the module) | `string` | `""` | no |
+| <a name="input_asm_role"></a> [asm\_role](#input\_asm\_role) | DEPRECATED: Use the new bot\_iam\_role input with he same semantics instead. | `string` | `""` | no |
+| <a name="input_boot_iam_role"></a> [boot\_iam\_role](#input\_boot\_iam\_role) | Specify arn of the role to apply to the boot job service account | `string` | `""` | no |
 | <a name="input_boot_secrets"></a> [boot\_secrets](#input\_boot\_secrets) | n/a | <pre>list(object({<br>    name  = string<br>    value = string<br>    type  = string<br>  }))</pre> | `[]` | no |
 | <a name="input_cluster_encryption_config"></a> [cluster\_encryption\_config](#input\_cluster\_encryption\_config) | Configuration block with encryption configuration for the cluster. | <pre>list(object({<br>    provider_key_arn = string<br>    resources        = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_cluster_endpoint_private_access"></a> [cluster\_endpoint\_private\_access](#input\_cluster\_endpoint\_private\_access) | Indicates whether or not the Amazon EKS private API server endpoint is enabled. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,7 @@ module "cluster" {
   enable_repository_storage             = var.enable_repository_storage
   boot_secrets                          = var.boot_secrets
   use_asm                               = var.use_asm
-  asm_role                              = var.asm_role
+  boot_iam_role                         = "${var.asm_role}${var.boot_iam_role}"
 }
 
 // ----------------------------------------------------------------------------

--- a/modules/cluster/local.tf
+++ b/modules/cluster/local.tf
@@ -15,7 +15,7 @@ locals {
   secret-infra-namespace = "secret-infra"
   git-operator-namespace = "jx-git-operator"
   project                = data.aws_caller_identity.current.account_id
-  boot_iam_role          = var.use_asm ? (var.create_asm_role ? module.iam_assumable_role_secrets-secrets-manager.this_iam_role_arn : var.asm_role) : ""
+  boot_iam_role          = var.create_asm_role ? module.iam_assumable_role_secrets-secrets-manager.this_iam_role_arn : var.boot_iam_role
 
   node_group_defaults = {
     ami_type         = var.node_group_ami

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -436,8 +436,8 @@ variable "use_asm" {
   default     = false
 }
 
-variable "asm_role" {
-  description = "Specify arn of the ASM role (custom not created by the module)"
+variable "boot_iam_role" {
+  description = "Specify arn of the role to apply to the boot job service account"
   type        = string
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -467,7 +467,7 @@ variable "use_asm" {
 }
 
 variable "asm_role" {
-  description = "Specify arn of the ASM role (custom not created by the module). Alias of boot_iam_role."
+  description = "DEPRECATED: Use the new bot_iam_role input with he same semantics instead."
   type        = string
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -467,7 +467,13 @@ variable "use_asm" {
 }
 
 variable "asm_role" {
-  description = "Specify arn of the ASM role (custom not created by the module)"
+  description = "Specify arn of the ASM role (custom not created by the module). Alias of boot_iam_role."
+  type        = string
+  default     = ""
+}
+
+variable "boot_iam_role" {
+  description = "Specify arn of the role to apply to the boot job service account"
   type        = string
   default     = ""
 }


### PR DESCRIPTION
Unless you set use_asm it was previously not possible to set boot_iam_role.
You couldn't add it with 

    boot_secrets                    = [
        {
            name  = "bootServiceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
            value = "arn:aws:iam::${var.aws_account}:role/jx-boot-job"
            type  = "string"
        }
    ]

either, since it would be overwritten with an empty value,

Since the role can be used for other things than asm I added a new input to make that clear.

<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated
-->
