### PR TITLE
S3 Block Public Access Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ Each example generates a valid _jx-requirements.yml_ file that can be used to bo
 | <a name="input_enable_external_dns"></a> [enable\_external\_dns](#input\_enable\_external\_dns) | Flag to enable or disable External DNS in the final `jx-requirements.yml` file | `bool` | `false` | no |
 | <a name="input_enable_key_name"></a> [enable\_key\_name](#input\_enable\_key\_name) | Flag to enable ssh key pair name | `bool` | `false` | no |
 | <a name="input_enable_key_rotation"></a> [enable\_key\_rotation](#input\_enable\_key\_rotation) | Flag to enable kms key rotation | `bool` | `true` | no |
-| <a name="input_enable_acl"></a> [enable\_acl](#input\_enable\_acl) | Flag to enable or disable acl long term storage type | `bool` | `true` | no |
+| <a name="input_enable_acl"></a> [enable\_acl](#input\_enable\_acl) | Flag to enable or disable acl long term storage type | `bool` | `false` | no |
 | <a name="input_enable_logs_storage"></a> [enable\_logs\_storage](#input\_enable\_logs\_storage) | Flag to enable or disable long term storage for logs | `bool` | `true` | no |
 | <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | Should be true if you want to provision NAT Gateways for each of your private networks | `bool` | `false` | no |
 | <a name="input_enable_reports_storage"></a> [enable\_reports\_storage](#input\_enable\_reports\_storage) | Flag to enable or disable long term storage for reports | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ This allows you to remove all generated buckets when running terraform destroy.
 
 :warning: **Note**: If you set `force_destroy` to false, and run a `terraform destroy`, it will fail. In that case empty the s3 buckets from the aws s3 console, and re run `terraform destroy`.
 
+:warning: **Note**: A notice from Amazon: [Amazon S3 will automatically enable S3 Block Public Access and disable access control lists for all new buckets starting in April 2023](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/). To resolve this issue you can set the `enable_acl` variable to false. 
+
+
 ### Secrets Management
 
 Vault is the default tool used by Jenkins X for managing secrets.
@@ -730,6 +733,7 @@ Each example generates a valid _jx-requirements.yml_ file that can be used to bo
 | <a name="input_enable_external_dns"></a> [enable\_external\_dns](#input\_enable\_external\_dns) | Flag to enable or disable External DNS in the final `jx-requirements.yml` file | `bool` | `false` | no |
 | <a name="input_enable_key_name"></a> [enable\_key\_name](#input\_enable\_key\_name) | Flag to enable ssh key pair name | `bool` | `false` | no |
 | <a name="input_enable_key_rotation"></a> [enable\_key\_rotation](#input\_enable\_key\_rotation) | Flag to enable kms key rotation | `bool` | `true` | no |
+| <a name="input_enable_acl"></a> [enable\_acl](#input\_enable\_acl) | Flag to enable or disable acl long term storage type | `bool` | `true` | no |
 | <a name="input_enable_logs_storage"></a> [enable\_logs\_storage](#input\_enable\_logs\_storage) | Flag to enable or disable long term storage for logs | `bool` | `true` | no |
 | <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | Should be true if you want to provision NAT Gateways for each of your private networks | `bool` | `false` | no |
 | <a name="input_enable_reports_storage"></a> [enable\_reports\_storage](#input\_enable\_reports\_storage) | Flag to enable or disable long term storage for reports | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ This allows you to remove all generated buckets when running terraform destroy.
 
 :warning: **Note**: If you set `force_destroy` to false, and run a `terraform destroy`, it will fail. In that case empty the s3 buckets from the aws s3 console, and re run `terraform destroy`.
 
-:warning: **Note**: A notice from Amazon: [Amazon S3 will automatically enable S3 Block Public Access and disable access control lists for all new buckets starting in April 2023](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/). To resolve this issue you can set the `enable_acl` variable to false. 
+:warning: **Note**: A notice from Amazon: [Amazon S3 will automatically enable S3 Block Public Access and disable access control lists for all new buckets starting in April 2023](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/). To accomodate this acl setting was removed for buckets and the `enable_acl` variable was introduced and set to false (default). If the requirement is to provide ACL with bucket ownership conrols for the bucket, then set the `enable_acl` variable to true.   
 
 
 ### Secrets Management
@@ -729,7 +729,7 @@ Each example generates a valid _jx-requirements.yml_ file that can be used to bo
 | <a name="input_create_velero_role"></a> [create\_velero\_role](#input\_create\_velero\_role) | Flag to control velero iam role creation | `bool` | `true` | no |
 | <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | Controls if VPC and related resources should be created. If you have an existing vpc for jx, set it to false | `bool` | `true` | no |
 | <a name="input_desired_node_count"></a> [desired\_node\_count](#input\_desired\_node\_count) | The number of worker nodes to use for the cluster | `number` | `3` | no |
-| <a name="input_enable_acl"></a> [enable\_acl](#input\_enable\_acl) | Flag to enable ACL instead of bucket ownership for S3 storage | `bool` | `false` | no |
+| <a name="input_enable_acl"></a> [enable\_acl](#input\_enable\_acl) | Flag to enable ACL along with bucket ownership controls for S3 storage | `bool` | `false` | no |
 | <a name="input_enable_backup"></a> [enable\_backup](#input\_enable\_backup) | Whether or not Velero backups should be enabled | `bool` | `false` | no |
 | <a name="input_enable_external_dns"></a> [enable\_external\_dns](#input\_enable\_external\_dns) | Flag to enable or disable External DNS in the final `jx-requirements.yml` file | `bool` | `false` | no |
 | <a name="input_enable_key_name"></a> [enable\_key\_name](#input\_enable\_key\_name) | Flag to enable ssh key pair name | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -670,8 +670,8 @@ Each example generates a valid _jx-requirements.yml_ file that can be used to bo
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | > 4.0, < 5.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.64.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 #### Modules
 
 | Name | Source | Version |
@@ -729,11 +729,11 @@ Each example generates a valid _jx-requirements.yml_ file that can be used to bo
 | <a name="input_create_velero_role"></a> [create\_velero\_role](#input\_create\_velero\_role) | Flag to control velero iam role creation | `bool` | `true` | no |
 | <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | Controls if VPC and related resources should be created. If you have an existing vpc for jx, set it to false | `bool` | `true` | no |
 | <a name="input_desired_node_count"></a> [desired\_node\_count](#input\_desired\_node\_count) | The number of worker nodes to use for the cluster | `number` | `3` | no |
+| <a name="input_enable_acl"></a> [enable\_acl](#input\_enable\_acl) | Flag to enable ACL instead of bucket ownership for S3 storage | `bool` | `false` | no |
 | <a name="input_enable_backup"></a> [enable\_backup](#input\_enable\_backup) | Whether or not Velero backups should be enabled | `bool` | `false` | no |
 | <a name="input_enable_external_dns"></a> [enable\_external\_dns](#input\_enable\_external\_dns) | Flag to enable or disable External DNS in the final `jx-requirements.yml` file | `bool` | `false` | no |
 | <a name="input_enable_key_name"></a> [enable\_key\_name](#input\_enable\_key\_name) | Flag to enable ssh key pair name | `bool` | `false` | no |
 | <a name="input_enable_key_rotation"></a> [enable\_key\_rotation](#input\_enable\_key\_rotation) | Flag to enable kms key rotation | `bool` | `true` | no |
-| <a name="input_enable_acl"></a> [enable\_acl](#input\_enable\_acl) | Flag to enable or disable acl long term storage type | `bool` | `false` | no |
 | <a name="input_enable_logs_storage"></a> [enable\_logs\_storage](#input\_enable\_logs\_storage) | Flag to enable or disable long term storage for logs | `bool` | `true` | no |
 | <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | Should be true if you want to provision NAT Gateways for each of your private networks | `bool` | `false` | no |
 | <a name="input_enable_reports_storage"></a> [enable\_reports\_storage](#input\_enable\_reports\_storage) | Flag to enable or disable long term storage for reports | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -104,6 +104,7 @@ module "cluster" {
   boot_secrets                          = var.boot_secrets
   use_asm                               = var.use_asm
   boot_iam_role                         = "${var.asm_role}${var.boot_iam_role}"
+  enable_acl                            = var.enable_acl
 }
 
 // ----------------------------------------------------------------------------
@@ -118,6 +119,7 @@ module "vault" {
   external_vault = local.external_vault
   use_vault      = var.use_vault
   region         = var.region
+  enable_acl     = var.enable_acl
 }
 
 // ----------------------------------------------------------------------------
@@ -131,6 +133,7 @@ module "backup" {
   force_destroy      = var.force_destroy
   velero_username    = var.velero_username
   create_velero_role = var.create_velero_role
+  enable_acl         = var.enable_acl
 }
 
 // ----------------------------------------------------------------------------

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -19,9 +19,18 @@ resource "aws_s3_bucket" "backup_bucket" {
 }
 
 resource "aws_s3_bucket_acl" "backup_bucket" {
-  count  = var.enable_backup ? 1 : 0
+  count  = var.enable_backup && var.enable_acl ? 1 : 0
   bucket = aws_s3_bucket.backup_bucket[0].bucket
   acl    = "private"
+}
+
+resource "aws_s3_bucket_ownership_controls" "backup_bucket" {
+  count  = var.enable_backup && !var.enable_acl ? 1 : 0
+  bucket = aws_s3_bucket.backup_bucket[0].bucket
+
+  rule {
+      object_ownership = "BucketOwnerEnforced"
+    }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "backup_bucket" {

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -29,8 +29,8 @@ resource "aws_s3_bucket_ownership_controls" "backup_bucket" {
   bucket = aws_s3_bucket.backup_bucket[0].bucket
 
   rule {
-      object_ownership = "BucketOwnerEnforced"
-    }
+    object_ownership = "BucketOwnerEnforced"
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "backup_bucket" {

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -25,7 +25,7 @@ resource "aws_s3_bucket_acl" "backup_bucket" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "backup_bucket" {
-  count  = var.enable_backup && !var.enable_acl ? 1 : 0
+  count  = var.enable_backup && var.enable_acl ? 1 : 0
   bucket = aws_s3_bucket.backup_bucket[0].bucket
 
   rule {

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -55,3 +55,8 @@ variable "create_velero_role" {
   type        = bool
   default     = true
 }
+
+variable "enable_acl" {
+  description = "Flag to enable ACL instead of bucket ownership for S3 storage"
+  type        = bool
+}

--- a/modules/cluster/storage.tf
+++ b/modules/cluster/storage.tf
@@ -20,9 +20,18 @@ resource "aws_s3_bucket" "logs_jenkins_x" {
 }
 
 resource "aws_s3_bucket_acl" "logs_jenkins_x" {
-  count  = var.enable_logs_storage ? 1 : 0
+  count  = var.enable_logs_storage && var.enable_acl ? 1 : 0
   bucket = aws_s3_bucket.logs_jenkins_x[0].bucket
   acl    = "private"
+}
+
+resource "aws_s3_bucket_ownership_controls" "logs_jenkins_x" {
+  count  = var.enable_logs_storage  && !var.enable_acl ? 1 : 0
+  bucket = aws_s3_bucket.logs_jenkins_x[0].bucket
+
+  rule {
+      object_ownership = "BucketOwnerEnforced"
+    }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "logs_jenkins_x" {
@@ -50,9 +59,18 @@ resource "aws_s3_bucket" "reports_jenkins_x" {
 }
 
 resource "aws_s3_bucket_acl" "reports_jenkins_x" {
-  count  = var.enable_reports_storage ? 1 : 0
+  count  = var.enable_reports_storage && var.enable_acl ? 1 : 0
   bucket = aws_s3_bucket.reports_jenkins_x[0].bucket
   acl    = "private"
+}
+
+resource "aws_s3_bucket_ownership_controls" "reports_jenkins_x" {
+  count  = var.enable_logs_storage && !var.enable_acl ? 1 : 0
+  bucket = aws_s3_bucket.reports_jenkins_x[0].bucket
+
+  rule {
+      object_ownership = "BucketOwnerEnforced"
+    }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "reports_jenkins_x" {
@@ -81,9 +99,18 @@ resource "aws_s3_bucket" "repository_jenkins_x" {
 }
 
 resource "aws_s3_bucket_acl" "repository_jenkins_x" {
-  count  = var.enable_repository_storage ? 1 : 0
+   count  = var.enable_repository_storage && var.enable_acl ? 1 : 0
+   bucket = aws_s3_bucket.repository_jenkins_x[0].bucket
+   acl    = "private"
+}
+
+resource "aws_s3_bucket_ownership_controls" "repository_jenkins_x" {
+  count  = var.enable_logs_storage && !var.enable_acl ? 1 : 0
   bucket = aws_s3_bucket.repository_jenkins_x[0].bucket
-  acl    = "private"
+
+  rule {
+      object_ownership = "BucketOwnerEnforced"
+    }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "repository_jenkins_x" {

--- a/modules/cluster/storage.tf
+++ b/modules/cluster/storage.tf
@@ -65,7 +65,7 @@ resource "aws_s3_bucket_acl" "reports_jenkins_x" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "reports_jenkins_x" {
-  count  = var.enable_logs_storage && !var.enable_acl ? 1 : 0
+  count  = var.enable_reports_storage && !var.enable_acl ? 1 : 0
   bucket = aws_s3_bucket.reports_jenkins_x[0].bucket
 
   rule {
@@ -105,7 +105,7 @@ resource "aws_s3_bucket_acl" "repository_jenkins_x" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "repository_jenkins_x" {
-  count  = var.enable_logs_storage && !var.enable_acl ? 1 : 0
+  count  = var.enable_repository_storage && !var.enable_acl ? 1 : 0
   bucket = aws_s3_bucket.repository_jenkins_x[0].bucket
 
   rule {

--- a/modules/cluster/storage.tf
+++ b/modules/cluster/storage.tf
@@ -26,7 +26,7 @@ resource "aws_s3_bucket_acl" "logs_jenkins_x" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "logs_jenkins_x" {
-  count  = var.enable_logs_storage && !var.enable_acl ? 1 : 0
+  count  = var.enable_logs_storage && var.enable_acl ? 1 : 0
   bucket = aws_s3_bucket.logs_jenkins_x[0].bucket
 
   rule {
@@ -65,7 +65,7 @@ resource "aws_s3_bucket_acl" "reports_jenkins_x" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "reports_jenkins_x" {
-  count  = var.enable_reports_storage && !var.enable_acl ? 1 : 0
+  count  = var.enable_reports_storage && var.enable_acl ? 1 : 0
   bucket = aws_s3_bucket.reports_jenkins_x[0].bucket
 
   rule {
@@ -105,7 +105,7 @@ resource "aws_s3_bucket_acl" "repository_jenkins_x" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "repository_jenkins_x" {
-  count  = var.enable_repository_storage && !var.enable_acl ? 1 : 0
+  count  = var.enable_repository_storage && var.enable_acl ? 1 : 0
   bucket = aws_s3_bucket.repository_jenkins_x[0].bucket
 
   rule {

--- a/modules/cluster/storage.tf
+++ b/modules/cluster/storage.tf
@@ -26,12 +26,12 @@ resource "aws_s3_bucket_acl" "logs_jenkins_x" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "logs_jenkins_x" {
-  count  = var.enable_logs_storage  && !var.enable_acl ? 1 : 0
+  count  = var.enable_logs_storage && !var.enable_acl ? 1 : 0
   bucket = aws_s3_bucket.logs_jenkins_x[0].bucket
 
   rule {
-      object_ownership = "BucketOwnerEnforced"
-    }
+    object_ownership = "BucketOwnerEnforced"
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "logs_jenkins_x" {
@@ -69,8 +69,8 @@ resource "aws_s3_bucket_ownership_controls" "reports_jenkins_x" {
   bucket = aws_s3_bucket.reports_jenkins_x[0].bucket
 
   rule {
-      object_ownership = "BucketOwnerEnforced"
-    }
+    object_ownership = "BucketOwnerEnforced"
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "reports_jenkins_x" {
@@ -99,9 +99,9 @@ resource "aws_s3_bucket" "repository_jenkins_x" {
 }
 
 resource "aws_s3_bucket_acl" "repository_jenkins_x" {
-   count  = var.enable_repository_storage && var.enable_acl ? 1 : 0
-   bucket = aws_s3_bucket.repository_jenkins_x[0].bucket
-   acl    = "private"
+  count  = var.enable_repository_storage && var.enable_acl ? 1 : 0
+  bucket = aws_s3_bucket.repository_jenkins_x[0].bucket
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_ownership_controls" "repository_jenkins_x" {
@@ -109,8 +109,8 @@ resource "aws_s3_bucket_ownership_controls" "repository_jenkins_x" {
   bucket = aws_s3_bucket.repository_jenkins_x[0].bucket
 
   rule {
-      object_ownership = "BucketOwnerEnforced"
-    }
+    object_ownership = "BucketOwnerEnforced"
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "repository_jenkins_x" {

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -441,3 +441,8 @@ variable "boot_iam_role" {
   type        = string
   default     = ""
 }
+
+variable "enable_acl" {
+  description = "Flag to enable ACL instead of bucket ownership for S3 storage"
+  type        = bool
+}

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -50,7 +50,7 @@ resource "aws_s3_bucket_acl" "vault-unseal-bucket" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "vault-unseal-bucket" {
-  count  = local.create_vault_resources && !var.enable_acl ? 1 : 0
+  count  = local.create_vault_resources && var.enable_acl ? 1 : 0
   bucket = aws_s3_bucket.vault-unseal-bucket[0].bucket
 
   rule {

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -44,9 +44,18 @@ resource "aws_s3_bucket" "vault-unseal-bucket" {
 }
 
 resource "aws_s3_bucket_acl" "vault-unseal-bucket" {
-  count  = local.create_vault_resources ? 1 : 0
+  count  = local.create_vault_resources && var.enable_acl ? 1 : 0
   bucket = aws_s3_bucket.vault-unseal-bucket[0].bucket
   acl    = "private"
+}
+
+resource "aws_s3_bucket_ownership_controls" "vault-unseal-bucket" {
+  count  = local.create_vault_resources && !var.enable_acl ? 1 : 0
+  bucket = aws_s3_bucket.vault-unseal-bucket[0].bucket
+
+  rule {
+      object_ownership = "BucketOwnerEnforced"
+    }
 }
 
 resource "aws_s3_bucket_versioning" "vault-unseal-bucket" {

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -54,8 +54,8 @@ resource "aws_s3_bucket_ownership_controls" "vault-unseal-bucket" {
   bucket = aws_s3_bucket.vault-unseal-bucket[0].bucket
 
   rule {
-      object_ownership = "BucketOwnerEnforced"
-    }
+    object_ownership = "BucketOwnerEnforced"
+  }
 }
 
 resource "aws_s3_bucket_versioning" "vault-unseal-bucket" {

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -79,3 +79,8 @@ variable "use_vault" {
   type        = bool
   default     = true
 }
+
+variable "enable_acl" {
+  description = "Flag to enable ACL instead of bucket ownership for S3 storage"
+  type        = bool
+}

--- a/variables.tf
+++ b/variables.tf
@@ -651,5 +651,5 @@ variable "boot_secrets" {
 variable "enable_acl" {
   description = "Flag to enable ACL instead of bucket ownership for S3 storage"
   type        = bool
-  default     = true
+  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -648,3 +648,8 @@ variable "boot_secrets" {
   }))
   default = []
 }
+variable "enable_acl" {
+  description = "Flag to enable ACL instead of bucket ownership for S3 storage"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
<!--
Add this section after we add tests and compliance
#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Change is covered by existing or new tests.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated
-->

#### Description
Starting in April 2023, Amazon S3 will introduce two new default bucket security settings by automatically enabling S3 Block Public Access and disabling S3 access control lists (ACLs) for all new S3 buckets. Once complete, these defaults will apply to all new buckets regardless of how they are created, including AWS CLI, APIs, SDKs, and AWS CloudFormation.

This AWS change results in the error **AccessControlListNotSupported: The bucket does not allow ACLs** when  creating a new EKS environment.

#### Special notes for the reviewer(s)
This change replaces the use of **_aws_s3_bucket_acl_** resource with the **_aws_s3_bucket_ownership_** resource. The rule for the ownership is **_BucketOwnerEnforced_**.

In the event ACL is still the preferred bucket permission type, you can set a new variable `enable_acl=true.` 

The tests were limited and run using both the **_Vault_** and **_AWS Secret Manager_** cluster config. The cluster environments created the S3 buckets without issue. Only the Vault configuration created additional folders under the bucket.

#### Which issue this PR fixes

fixes #8572

#### Release notes
