### PR TITLE
remove template provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,6 @@ terraform {
     kubernetes = "~> 2.0"
     local      = "~> 2.0"
     null       = "~> 3.0"
-    template   = "~> 2.0"
     random     = "~> 3.0"
     helm       = "~> 2.0"
   }


### PR DESCRIPTION
Remove 'template' from the list of required providers.

- None of the resources/datasources provided by this provider are currently in use.
- It has been deprecated since terraform 0.12 and no longer in development, e.g. there is no official build for darwin_arm64.

