### PR TITLE
feat: ebs csi driver addon output

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,11 +553,27 @@ In version 1.23 the Kubernetes in-tree to container storage interface (CSI) volu
 
 An add-on is software that provides supporting operational capabilities to Kubernetes applications, but is not specific to the application. This includes software like observability agents or Kubernetes drivers that allow the cluster to interact with underlying AWS resources for networking, compute, and storage. [EKS Addons Guide](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html)
 
-To enable the EBS CSI Driver (aws-ebs-csi-driver) set variables `enable_ebs_addon`and `create_addon_role` both  to true. The version of the driver addon is defined in the string variable `ebs_addon_version`
-To determine what versions of EBS CSI driver are supported use the command:
+The EBS CSI Driver (aws-ebs-csi-driver) by default is disabled. To enable set variables:
+```
+enable_ebs_addon = true
+create_addon_role = true
+ebs_addon_version = "v1.21.0-eksbuild.1"
+```
+To determine valid versions for variable `ebs_addon_version` use the command:
 ```
 aws eks describe-addon-versions --addon-name "aws-ebs-csi-driver" | jq -r '.addons[].addonVersions[].addonVersion'
 ```
+The EBS CSI Driver addon can be implemented successfully using **worker group launch templates**. The addon can be problematic when using the default **worker node groups** and is not recommended. For new installations set the following variables:
+```
+enable_worker_groups_launch_template = true
+enable_worker_group = false
+```
+For existing installations where `enable_worker_groups = true` only set the variable:
+```
+enable_worker_groups_launch_template = true
+```
+Once the addon is installed,  then perform [Transitioning from Worker Groups to Worker Groups Launch Templates](#transitioning-from-worker-groups-to-worker-groups-launch-templates). When completed the variable `enable_worker_group = false`
+
 
 :warning: **Note**: It is imperative that you export the environment variable `AWS_REGION` with the appropriate region value (i.e. us-west-2). 
 ### AWS Auth

--- a/README.md
+++ b/README.md
@@ -563,19 +563,11 @@ To determine valid versions for variable `ebs_addon_version` use the command:
 ```
 aws eks describe-addon-versions --addon-name "aws-ebs-csi-driver" | jq -r '.addons[].addonVersions[].addonVersion'
 ```
-The EBS CSI Driver addon can be implemented successfully using **worker group launch templates**. The addon can be problematic when using the default **worker node groups** and is not recommended. For new installations set the following variables:
-```
-enable_worker_groups_launch_template = true
-enable_worker_group = false
-```
-For existing installations where `enable_worker_groups = true` only set the variable:
+The EBS CSI Driver addon can be implemented successfully using **worker group launch templates**. Also set the following variable:
 ```
 enable_worker_groups_launch_template = true
 ```
-Once the addon is installed,  then perform [Transitioning from Worker Groups to Worker Groups Launch Templates](#transitioning-from-worker-groups-to-worker-groups-launch-templates). When completed the variable `enable_worker_group = false`
 
-
-:warning: **Note**: It is imperative that you export the environment variable `AWS_REGION` with the appropriate region value (i.e. us-west-2). 
 ### AWS Auth
 
 When running EKS, authentication for the cluster is controlled by a `configmap` called `aws-auth`. By default, that should look something like this:

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -94,3 +94,8 @@ output "pipeline_viz_iam_role" {
   value       = module.iam_assumable_role_pipeline_visualizer.this_iam_role_name
   description = "The IAM Role that the pipeline visualizer pod will assume to authenticate"
 }
+
+output "ebscsi_addon_iam_role" {
+  value       = module.ebs_csi_irsa_role.iam_role_name
+  description = "The IAM Role that the build pods will assume to authenticate"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -103,6 +103,10 @@ output "cluster_ssm_iam_role" {
 
 }
 
+output "ebscsi_addon_iam_role" {
+  value       = module.cluster.ebscsi_addon_iam_role
+  description = "The IAM Role that the EBS CSI Driver addon  will assume to authenticate"
+}
 // ----------------------------------------------------------------------------
 // Vault Resources
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
#### Description
The latest release for the eks-jx module 1.21.8  does not include output variables for the new addon irsa role. This request provides the variables and updates to the README.md on how to enable EBS CSI driver addon.

#### Special notes for the reviewer(s)
The following output variable should also be added to [https://github.com/jx3-gitops-repositories/jx3-terraform-eks/output.tf](https://github.com/jx3-gitops-repositories/jx3-terraform-eks/blob/main/output.tf)
```
output "ebscsi_addon_iam_role" {
  value       = module.eks-jx.ebscsi_addon_iam_role
  description = "The IAM Role that the build pods will assume to authenticate"
}
```
