### PR TITLE
fix: abort incomplete uploads to s3 bucket (#379)

### DIFF
--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -45,7 +45,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "backup_bucket" {
 
 resource "aws_s3_bucket_lifecycle_configuration" "backup_bucket" {
   count  = var.enable_backup ? 1 : 0
-  bucket   = aws_s3_bucket.backup_bucket.id
+  bucket   = aws_s3_bucket.backup_bucket[0].id
   rule {
     status = "Enabled"
     id     = "abort_incomplete_uploads"

--- a/modules/cluster/storage.tf
+++ b/modules/cluster/storage.tf
@@ -46,7 +46,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "logs_jenkins_x" {
 
 resource "aws_s3_bucket_lifecycle_configuration" "logs_jenkins_x" {
   count  = var.enable_logs_storage ? 1 : 0
-  bucket   = aws_s3_bucket.logs_jenkins_x.id
+  bucket   = aws_s3_bucket.logs_jenkins_x[0].id
   rule {
     status = "Enabled"
     id     = "abort_incomplete_uploads"
@@ -95,7 +95,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "reports_jenkins_x
 
 resource "aws_s3_bucket_lifecycle_configuration" "reports_jenkins_x" {
   count  = var.enable_reports_storage ? 1 : 0
-  bucket   = aws_s3_bucket.reports_jenkins_x.id
+  bucket   = aws_s3_bucket.reports_jenkins_x[0].id
   rule {
     status = "Enabled"
     id     = "abort_incomplete_uploads"
@@ -145,7 +145,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "repository_jenkin
 
 resource "aws_s3_bucket_lifecycle_configuration" "repository_jenkins_x" {
   count  = var.enable_repository_storage ? 1 : 0
-  bucket   = aws_s3_bucket.repository_jenkins_x.id
+  bucket   = aws_s3_bucket.repository_jenkins_x[0].id
   rule {
     status = "Enabled"
     id     = "abort_incomplete_uploads"


### PR DESCRIPTION
As a best practice to save costs there should be a lifecycle configuration on s3 buckets to abort incomplete uploads

https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpu-abort-incomplete-mpu-lifecycle-config.html

#### Description

#### Submitter checklist

- [ ] Change is code complete and matches issue description.
- [ ] Readme and jx-docs (https://jenkins-x.io/docs/install-setup/installing/create-cluster/eks/) are updated

#### Special notes for the reviewer(s)

#### Which issue this PR fixes

fixes #

#### Release notes
