### PR TITLE
fix: aws provider limit < 6.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "> 4.0"
+      version = "> 4.0, < 6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
#### Description
Current EKS Infra code issues errors when using the default `hashicorp/aws provider 6.0.` due to the deprecation of `aws_launch_template elastic_gpu_specifications`

Change in the `versions.tf` file limits the provider version to **< 6.0** allowing for code to use the hashicorp/aws **version 5.100.0.**

#### Which issue this PR fixes

fixes #
[#396](https://github.com/jenkins-x/terraform-aws-eks-jx/issues/396)
#### Release notes
